### PR TITLE
amcrest/cli: Add --get-snapshot and --output

### DIFF
--- a/cli/amcrest-cli
+++ b/cli/amcrest-cli
@@ -41,6 +41,15 @@ def main():
                         dest='port',
                         default=80,
                         help='port to Amcrest camera. Default: 80')
+    parser.add_argument('--get-snapshot',
+                        dest='snapshot_option',
+                        default='0',
+                        nargs='?',
+                        const='0',
+                        help='get snapshot, use 0, 1 or 2\n'
+                             '0 - regular snapshot\n'
+                             '1 - motion detection snapshot\n'
+                             '2 - alarm snapshot')
     parser.add_argument('--get-current-time',
                         action='store_true',
                         help='Get camera current time')
@@ -53,6 +62,9 @@ def main():
     parser.add_argument('--disable-motion-detection',
                         action='store_true',
                         help='Disable motion detection.')
+    parser.add_argument('--output',
+                        dest='output',
+                        help='output file name')
     args = parser.parse_args()
 
     camera = AmcrestCamera(
@@ -76,6 +88,9 @@ def main():
 
     elif args.disable_motion_detection:
         print((camera.disable_motion_detection()))
+
+    elif args.snapshot_option:
+        camera.get_snapshot(args.snapshot_option, args.output)
 
     else:
         print('Error: You must specify a valid operation. See usage:')

--- a/man/amcrest-cli.1
+++ b/man/amcrest-cli.1
@@ -13,6 +13,15 @@ Displays a list of options.
 .B --get-current-time
 Get current time from camera.
 .TP
+.B --get-snapshot
+Get snapshot, use one of the following options:
+.br
+0 - regular snapshot
+.br
+1 - motion detection snapshot
+.br
+2 - alarm snapshot
+.TP
 .B --motion-detection-status
 Returns if the motion detection is enabled or disabled
 .TP
@@ -22,7 +31,12 @@ Enable motion detection
 .B --disable-motion-detection
 Disable motion detection
 .TP
-.RE
+.B --output
+output file name, useful for options like --get-snapshot
+.SH EXAMPLES
+.TP
+.B Grab snapshot and save in /tmp/self.jpeg
+$ amcrest-cli -H 192.168.1.10 -u admin -p password --get-snapshot --output /tmp/self.jpeg
 .SH BUGS
 Report bugs to <https://github.com/tchellomello/python-amcrest/issues>
 .SH COPYRIGHT


### PR DESCRIPTION
This change introduce few changes:

- Rework command(), now returns the pure return from request
- Users are now able to grab a snapshot
- Might use --output to specify the file, like --output foobar.jpeg