### PR TITLE
spec: call autocomplete reg in cli post

### DIFF
--- a/python-amcrest.spec.in
+++ b/python-amcrest.spec.in
@@ -115,6 +115,9 @@ make %{?_smp_mflags}
 %install
 make %{?_smp_mflags} install DESTDIR="%{buildroot}"
 
+%post -n amcrest-cli
+eval "$(register-python-argcomplete amcrest-cli)"
+
 %check
 %if 0%{?with_check}
 make check-local


### PR DESCRIPTION
After install, if users decide to use the amcrest-cli
as root and take the benefit of autocomplete we need to
register it.