### PR TITLE
 Added option --credentials that allows the user to read credentials from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,16 @@ $ man amcrest-cli
 or
 
 $ amcrest-cli --help
+
+
+Reading credentials from a file:
+$ cat ~/camera1.cfg
+[camera1]
+hostname: camera1.example.com
+username: admin
+password: 123456
+port: 80
+
+$ amcrest-cli --credentials ~/camera1.cfg  --version-http-api
+version=1.40
+```

--- a/cli/amcrest-cli
+++ b/cli/amcrest-cli
@@ -12,6 +12,13 @@
 #
 # vim:sw=4:ts=4:et
 
+try:
+    #import for Python 2.x
+    from ConfigParser import ConfigParser
+except:
+    #import for Python 3.x
+    from configparser import ConfigParser
+
 import argcomplete
 import argparse
 import os
@@ -51,6 +58,10 @@ def main():
 
     # FIXME: Add metavar in the options for better understanding in the
     # --help output
+
+    parser.add_argument('--credentials',
+                        dest='credentials',
+                        help='filename with Amcrest camera credentials')
 
     parser.add_argument('-H', '--hostname',
                         dest='hostname',
@@ -421,6 +432,18 @@ def main():
 
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
+
+    if args.credentials:
+        config = ConfigParser()
+        config['DEFAULT'] = { 'username':  'admin',
+                              'password':  'admin',
+                              'port': 80 }
+        config.read(args.credentials)
+        section = config.sections()[0]
+        args.hostname = config.get(section, 'hostname')
+        args.port = config.getint(section, 'port')
+        args.username = config.get(section, 'username')
+        args.password = config.get(section, 'password')
 
     amcrest = AmcrestCamera(
         args.hostname,

--- a/man/amcrest-cli.1
+++ b/man/amcrest-cli.1
@@ -2,13 +2,28 @@
 .SH NAME
 amcrest-cli \- A tool to manage Amcrest camera
 .SH SYNOPSIS
-amcrest-cli -H HOSTNAME -u USERNAME -p PASSWORD [options]
+amcrest-cli [-H HOSTNAME -u USERNAME -p PASSWORD] [--credentials <filename>] [options]
 .SH DESCRIPTION
 \fBamcrest-cli\fP is a command line tool to manage Amcrest camera
 .SH OPTIONS
 .TP
 .B -h, --help
 Displays a list of options.
+.TP
+.B --credentials
+Read credentials from a file to connect to the camera.
+.PP
+.RS
+[mycamera1]
+.br
+hostname: mycamera1.example.com
+.br
+username: admin      #if omitted, defaults to admin
+.br
+password: 1234567    #if omitted, defaults to admin
+.br
+port: 80             #if omitted, defaults to 80
+.RE
 .TP
 .B --current-time
 Get current time from camera.


### PR DESCRIPTION
 Added option --credentials that allows the user to read credentials from a file
```bash
$ cat ~/camera1.cfg
[camera1]
hostname: camera1.example.com
username: admin
password: 123456
port: 80

$ amcrest-cli --credentials ~/camera1.cfg --version-http-api
version=1.40
```