### PR TITLE
Modified behavior to have a generic configuration file (if applicable to load the credentials for Amcrest cameras.)

### DIFF
--- a/cli/amcrest-cli
+++ b/cli/amcrest-cli
@@ -14,10 +14,10 @@
 
 try:
     #import for Python 2.x
-    from ConfigParser import ConfigParser
+    from ConfigParser import ConfigParser, NoOptionError, NoSectionError
 except:
     #import for Python 3.x
-    from configparser import ConfigParser
+    from configparser import ConfigParser, NoOptionError, NoSectionError
 
 import argcomplete
 import argparse
@@ -449,10 +449,14 @@ def main():
         else:
             section = config.sections()[0]
 
-        args.hostname = config.get(section, 'hostname')
-        args.port = config.getint(section, 'port')
-        args.username = config.get(section, 'username')
-        args.password = config.get(section, 'password')
+        try:
+            args.hostname = config.get(section, 'hostname')
+            args.port = config.getint(section, 'port')
+            args.username = config.get(section, 'username')
+            args.password = config.get(section, 'password')
+        except (NoSectionError, NoOptionError) as e:
+            print("ERROR! %s found at %s" % (e, AMCREST_CONF))
+            return
 
     amcrest = AmcrestCamera(
         args.hostname,

--- a/cli/amcrest-cli
+++ b/cli/amcrest-cli
@@ -28,6 +28,7 @@ import threading
 
 from amcrest import AmcrestCamera
 
+AMCREST_CONF=os.path.join(os.getenv("HOME"), '.config/amcrest.conf')
 
 def graceful_exit(_signo, _stack_frame):
     """
@@ -59,10 +60,6 @@ def main():
     # FIXME: Add metavar in the options for better understanding in the
     # --help output
 
-    parser.add_argument('--credentials',
-                        dest='credentials',
-                        help='filename with Amcrest camera credentials')
-
     parser.add_argument('-H', '--hostname',
                         dest='hostname',
                         help='hostname or ip address for Amcrest camera')
@@ -82,6 +79,10 @@ def main():
                         dest='port',
                         default=80,
                         help='port to Amcrest camera. Default: 80')
+
+    parser.add_argument('--camera',
+                        dest='camera',
+                        help='specify which section to read from ~/.config/amcrest.conf')
 
     parser.add_argument('--info-user',
                         dest='info_user',
@@ -433,13 +434,21 @@ def main():
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
-    if args.credentials:
+    if os.path.isfile(AMCREST_CONF) and not args.scan_devices:
         config = ConfigParser()
-        config['DEFAULT'] = { 'username':  'admin',
-                              'password':  'admin',
-                              'port': 80 }
-        config.read(args.credentials)
-        section = config.sections()[0]
+        config.read(AMCREST_CONF)
+
+        # if more cameras found, requires --camera option
+        if len(config.sections()) > 1 and not args.camera:
+            print("More than 1 camera found at %s. "
+                  "Append the --camera option." % AMCREST_CONF)
+            return
+
+        if args.camera:
+            section = args.camera
+        else:
+            section = config.sections()[0]
+
         args.hostname = config.get(section, 'hostname')
         args.port = config.getint(section, 'port')
         args.username = config.get(section, 'username')

--- a/man/amcrest-cli.1
+++ b/man/amcrest-cli.1
@@ -2,28 +2,46 @@
 .SH NAME
 amcrest-cli \- A tool to manage Amcrest camera
 .SH SYNOPSIS
-amcrest-cli [-H HOSTNAME -u USERNAME -p PASSWORD] [--credentials <filename>] [options]
+amcrest-cli [-H HOSTNAME -u USERNAME -p PASSWORD] [--camera <camera>] [options]
 .SH DESCRIPTION
-\fBamcrest-cli\fP is a command line tool to manage Amcrest camera
-.SH OPTIONS
-.TP
-.B -h, --help
-Displays a list of options.
-.TP
-.B --credentials
-Read credentials from a file to connect to the camera.
+\fBamcrest-cli\fP is a command line tool to manage Amcrest camera.
+.P
+By default it reads the default ~/.config/amcrest.conf configuration file.
+If the file does not exist, it requires the use of -H HOSTNAME -u USERNAME -p PASSWORD options.
+.P
+The current format for ~/.config/amcrest.conf is:
 .PP
 .RS
 [mycamera1]
 .br
 hostname: mycamera1.example.com
 .br
-username: admin      #if omitted, defaults to admin
+username: admin
 .br
-password: 1234567    #if omitted, defaults to admin
+password: 1234567
 .br
-port: 80             #if omitted, defaults to 80
+port: 80
+.P
+[mycamera2]
+.br
+hostname: mycamera2.example.com
+.br
+username: admin
+.br
+password: 7654321
+.br
+port: 80
 .RE
+.P
+Note that when having more than one camera defined, it will be required to use the option \fB--camera\fP.
+.PP
+.RS
+$ amcrest-cli --camera mycamera2 --save ~/Desktop/mycamera2_snapshot.jpg
+.RE
+.SH OPTIONS
+.TP
+.B -h, --help
+Displays a list of options.
 .TP
 .B --current-time
 Get current time from camera.
@@ -324,6 +342,8 @@ $ amcrest-cli -H 192.168.1.10 -u admin -p password --audio-stream-capture single
 $ amcrest-cli -H 192.168.1.10 -u admin -p password --mjpg-stream 20 --save /home/user/myfile.mjpg
 .SH BUGS
 Report bugs to <https://github.com/tchellomello/python-amcrest/issues>
+.SH "SEE ALSO"
+.BR amcrest-cli (1)
 .SH COPYRIGHT
 Copyright 2016
 License GPLv2: GNU GPL Version 2 <http://gnu.org/licenses/gpl.html>.


### PR DESCRIPTION
This patch allows to create a configuration file at ~/.config/amcrest.conf that can have multiple Amcrest camera instances to use via amcrest-cli. 

