### PR TITLE
Fixed issue #19 - config_backup() is a function instead property

### DIFF
--- a/src/amcrest/system.py
+++ b/src/amcrest/system.py
@@ -115,7 +115,6 @@ class System:
         )
         return ret.content.decode('utf-8')
 
-    @property
     def config_backup(self, filename=None):
         ret = self.command(
             'Config.backup?action=All'


### PR DESCRIPTION
Fixed issue #19 that should be a function instead a @property

```bash
» amcrest-cli  --camera amcrestcam1 --config-backup --save /tmp/cfg                                                                                 ~/d/h/homeassistant
Traceback (most recent call last):
  File "/home/mdemello/.virtualenvs/home_assistant/bin/amcrest-cli", line 863, in <module>
    main()
  File "/home/mdemello/.virtualenvs/home_assistant/bin/amcrest-cli", line 849, in main
    camera.config_backup(args.save)
TypeError: 'str' object is not callable
```

After applying the fix:

```bash
~ » amcrest-cli --camera amcrestcam1  --config-backup --save /tmp/lala22.txt 
~ » ls -la /tmp/lala22.txt                    
-rw-rw-r--. 1 user user 154734 Dec 14 19:23 /tmp/lala22.txt
```