### PR TITLE
http: improve handling of timeout/retries

### DIFF
--- a/src/amcrest/snapshot.py
+++ b/src/amcrest/snapshot.py
@@ -24,7 +24,7 @@ class Snapshot:
     def snapshot_config(self):
         return self.__get_config('Snap')
 
-    def snapshot(self, channel=0, path_file=None):
+    def snapshot(self, channel=0, path_file=None, timeout=None):
         """
         Args:
 
@@ -44,7 +44,8 @@ class Snapshot:
             raw from http request
         """
         ret = self.command(
-            "snapshot.cgi?=channel={0}".format(channel)
+            "snapshot.cgi?=channel={0}".format(channel),
+            timeout_cmd=timeout
         )
 
         if path_file:


### PR DESCRIPTION
User might want to set timeout and the number of retries
each connection should attempt. Previously, we used the static
default timeout of 3 and the retries of 3. This patch also adds
the possibility of snapshot call set timeout.