### PR TITLE
amcrest: dynamic timeout/retries http proto

### DIFF
--- a/cli/amcrest-cli
+++ b/cli/amcrest-cli
@@ -13,10 +13,10 @@
 # vim:sw=4:ts=4:et
 
 try:
-    #import for Python 2.x
+    # import for Python 2.x
     from ConfigParser import ConfigParser, NoOptionError, NoSectionError
 except:
-    #import for Python 3.x
+    # import for Python 3.x
     from configparser import ConfigParser, NoOptionError, NoSectionError
 
 import argcomplete
@@ -28,7 +28,8 @@ import threading
 
 from amcrest import AmcrestCamera
 
-AMCREST_CONF=os.path.join(os.getenv("HOME"), '.config/amcrest.conf')
+AMCREST_CONF = os.path.join(os.getenv("HOME"), '.config/amcrest.conf')
+
 
 def graceful_exit(_signo, _stack_frame):
     """
@@ -82,7 +83,8 @@ def main():
 
     parser.add_argument('--camera',
                         dest='camera',
-                        help='specify which section to read from ~/.config/amcrest.conf')
+                        help='specify which section to read from '
+                             '~/.config/amcrest.conf')
 
     parser.add_argument('--info-user',
                         dest='info_user',

--- a/src/amcrest/amcrest.py
+++ b/src/amcrest/amcrest.py
@@ -18,7 +18,8 @@ class AmcrestCamera(Http):
     """Amcrest camera object implementation."""
 
     def __init__(self, host, port, user,
-                 password, verbose=True, protocol='http'):
+                 password, verbose=True, protocol='http',
+                 retries_connection=None, timeout_protocol=None):
 
         self.camera = Http(
             host=host,
@@ -26,5 +27,7 @@ class AmcrestCamera(Http):
             user=user,
             password=password,
             verbose=verbose,
-            protocol=protocol
+            protocol=protocol,
+            retries_connection=retries_connection,
+            timeout_protocol=timeout_protocol
         )

--- a/src/amcrest/config.py
+++ b/src/amcrest/config.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015 Red Hat, Inc.
-#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, version 2 of the License.
@@ -10,29 +8,14 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
+#
+# vim:sw=4:ts=4:et
 
+# How long to wait for the server send data before giving up, as a float
+# or a (connect timeout, read timeout) tuple.
+# Default value from requests library is 3
+TIMEOUT_HTTP_PROTOCOL = 3.0
 
-MAINTAINERCLEANFILES = \
-        $(srcdir)/Makefile.in \
-        $(NULL)
-
-pycrestdir = $(amcrestpythonlibdir)
-
-pycrest_PYTHON = \
-	__init__.py \
-	amcrest.py \
-	http.py \
-	config.py \
-	system.py \
-	network.py \
-	motion_detection.py \
-	snapshot.py \
-	user_management.py \
-	event.py \
-	audio.py \
-	record.py \
-	video.py \
-	log.py \
-	ptz.py \
-	special.py \
-	$(NULL)
+# Retries - maximum number of retries each connection should attempt
+# Default value from requests library is 3
+MAX_RETRY_HTTP_CONNECTION = 3

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -12,7 +12,6 @@
 # vim:sw=4:ts=4:et
 import requests
 
-from distutils.util import strtobool
 from requests.adapters import HTTPAdapter
 
 from .audio import Audio
@@ -31,13 +30,17 @@ from .user_management import UserManagement
 from .utils import Utils
 from .video import Video
 
+from .config import TIMEOUT_HTTP_PROTOCOL, MAX_RETRY_HTTP_CONNECTION
+
 
 class Http(System, Network, MotionDetection, Snapshot,
            UserManagement, Event, Audio, Record, Video,
            Log, Ptz, Special, Storage, Utils, Nas):
 
     def __init__(self, host, port, user,
-                 password, verbose=True, protocol='http'):
+                 password, verbose=True, protocol='http',
+                 retries_connection=None, timeout_protocol=None):
+
         self._host = host
         self._port = port
         self._user = user
@@ -45,6 +48,16 @@ class Http(System, Network, MotionDetection, Snapshot,
         self._verbose = verbose
         self._protocol = protocol
         self._token = requests.auth.HTTPBasicAuth(self._user, self._password)
+
+        if timeout_protocol is None:
+            self._timeout_protocol = TIMEOUT_HTTP_PROTOCOL
+        else:
+            self._timeout_protocol = timeout_protocol
+
+        if retries_connection is None:
+            self._retries_conn = MAX_RETRY_HTTP_CONNECTION
+        else:
+            self._retries_conn = retries_connection
 
     # Base methods
     def __base_url(self, param=""):
@@ -58,23 +71,24 @@ class Http(System, Network, MotionDetection, Snapshot,
             timeout_cmd - timeout, default 3sec
             retries - maximum number of retries each connection should attempt
         """
-        if timeout_cmd is None:
-            timeout_cmd = 3.0
+        if timeout_cmd is not None:
+            self._timeout_protocol = timeout_cmd
 
-        if retries is None:
-            retries = 3
+        if retries is not None:
+            self._retries_conn = retries
 
         s = requests.Session()
-        s.mount('http://', HTTPAdapter(max_retries=retries))
-        s.mount('https://', HTTPAdapter(max_retries=retries))
+        s.mount('http://', HTTPAdapter(max_retries=self._retries_conn))
+        s.mount('https://', HTTPAdapter(max_retries=self._retries_conn))
 
+        print(self._timeout_protocol)
         url = self.__base_url(cmd)
         try:
             resp = s.get(
                 url,
                 auth=self._token,
                 stream=True,
-                timeout=timeout_cmd,
+                timeout=self._timeout_protocol,
             )
             resp.raise_for_status()
         except:

--- a/src/amcrest/motion_detection.py
+++ b/src/amcrest/motion_detection.py
@@ -10,6 +10,7 @@
 # GNU General Public License for more details.
 #
 # vim:sw=4:ts=4:et
+from .utils import str2bool
 
 
 class MotionDetection:
@@ -25,13 +26,15 @@ class MotionDetection:
 
     def is_motion_detector_on(self):
         ret = self.motion_detection
-        status = [s for s in ret.split() if '.Enable=' in s][0].split('=')[-1]
-        return self.str2bool(status)
+        status = [s for s in ret.split() if '.Enable=' in s][0].split(
+                '=')[-1]
+        return str2bool(status)
 
     def is_record_on_motion_detection(self):
         ret = self.motion_detection
-        status = [s for s in ret.split() if '.RecordEnable=' in s][0].split('=')[-1]
-        return self.str2bool(status)
+        status = [s for s in ret.split() if '.RecordEnable=' in s][0].split(
+                '=')[-1]
+        return str2bool(status)
 
     @motion_detection.setter
     def motion_detection(self, opt):

--- a/src/amcrest/record.py
+++ b/src/amcrest/record.py
@@ -37,17 +37,18 @@ class Record:
 
     @property
     def record_mode(self):
-        status_code = { 0 : 'Automatic',
-                        1 : 'Manual',
-                        2 : 'Stop',
-                        None: 'Unknown'}
+        status_code = {0: 'Automatic',
+                       1: 'Manual',
+                       2: 'Stop',
+                       None: 'Unknown'}
 
         ret = self.command(
             'configManager.cgi?action=getConfig&name=RecordMode'
         )
 
         try:
-            status = int([s for s in ret.content.decode('utf-8').split() if 'Mode=' in s][0].split('=')[-1])
+            status = int([s for s in ret.content.decode(
+                'utf-8').split() if 'Mode=' in s][0].split('=')[-1])
         except:
             status = None
 


### PR DESCRIPTION
Currently, the timeout and number of retries in http protocol
is static. This patch introduces config.py, which users might
change such settings. Looking for better intregration with
Home Assitant project now is possible to also set timeout/retries
during the instance call.