### PR TITLE
Created method to expose get_base_url()

### DIFF
--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -69,6 +69,8 @@ class Http(System, Network, MotionDetection, Snapshot,
     def __base_url(self, param=""):
         return '%s://%s:%s/cgi-bin/%s' % (self._protocol, self._host,
                                           str(self._port), param)
+    def get_base_url(self):
+        return self._base_url
 
     def command(self, cmd, retries=None, timeout_cmd=None):
         """

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -69,6 +69,7 @@ class Http(System, Network, MotionDetection, Snapshot,
     def __base_url(self, param=""):
         return '%s://%s:%s/cgi-bin/%s' % (self._protocol, self._host,
                                           str(self._port), param)
+
     def get_base_url(self):
         return self._base_url
 


### PR DESCRIPTION
Created method to expose get_base_url()
```python
In [4]: camera.get_base_url
Out[4]: 'http://192.168.169.188:80/cgi-bin/'
```