### PR TITLE
record: Add possibility to set record mode

### DIFF
--- a/cli/amcrest-cli
+++ b/cli/amcrest-cli
@@ -336,9 +336,15 @@ def main():
                         action='store_true',
                         help='show record capability')
 
+    parser.add_argument('--record-mode',
+                        nargs='?',
+                        const=-1,
+                        help='show/set record mode')
+
     parser.add_argument('--record-config',
-                        action='store_true',
-                        help='show record config')
+                        nargs='?',
+                        const=-1,
+                        help='show/set record config')
 
     parser.add_argument('--media-global-config',
                         action='store_true',
@@ -668,8 +674,20 @@ def main():
             print((camera.record_capability))
             return
 
-        elif args.record_config:
+        elif args.record_mode == -1:
+            print((camera.record_mode))
+            return
+
+        elif args.record_mode is not None:
+            camera.record_mode = args.record_mode
+            return
+
+        elif args.record_config == -1:
             print((camera.record_config))
+            return
+
+        elif args.record_config is not None:
+            camera.record_config = args.record_config
             return
 
         elif args.media_global_config:

--- a/man/amcrest-cli.1
+++ b/man/amcrest-cli.1
@@ -235,6 +235,9 @@ audio input channels numbers
 .B --audio-output-channels-numbers
 audio output channels numbers
 .TP
+.B --record-mode
+show/set record mode (0 Automatically record, 1 Manually Record, 0 Stop Record)
+.TP
 .B --record-capability
 show record capability
 .TP

--- a/src/amcrest/record.py
+++ b/src/amcrest/record.py
@@ -53,3 +53,30 @@ class Record:
             status = None
 
         return status_code[status]
+
+    @record_mode.setter
+    def record_mode(self, record_opt, channel=0):
+        """
+        Params:
+
+        channel:
+        video index, start from 0
+
+        record_opt:
+        +----------------------------+-----------------+-------------------+
+        | ParamName                  | ParamValue type | Description       |
+        +----------------------------+-----------------+-------------------+
+        | RecordMode[channel].Mode   | integer         | Range os {0, 1, 2}|
+        |                            |                 | 0: automatically  |
+        |                            |                 | 1: manually       |
+        |                            |                 | 2: stop record    |
+        +----------------------------+-----------------+-------------------+
+
+        record_opt format:
+        <paramName>=<paramValue>[&<paramName>=<paramValue>...]
+        """
+        ret = self.command(
+            'configManager.cgi?action=setConfig&RecordMode'
+            '[{0}].Mode={1}'.format(channel, record_opt)
+        )
+        return ret.content.decode('utf-8')


### PR DESCRIPTION
This patch adds:

- --record-mode to amcred-tui (For view and set option)
- adjust man for --record-mode
- prepare --record-config to be able to set options