### PR TITLE
Prompts password if the configuration file does not password parameter

### DIFF
--- a/cli/amcrest-cli
+++ b/cli/amcrest-cli
@@ -21,6 +21,7 @@ except:
 
 import argcomplete
 import argparse
+import getpass
 import os
 import signal
 import sys
@@ -490,7 +491,10 @@ def main():
             args.hostname = config.get(section, 'hostname')
             args.port = config.getint(section, 'port')
             args.username = config.get(section, 'username')
-            args.password = config.get(section, 'password')
+            try:
+                args.password = config.get(section, 'password')
+            except NoOptionError:
+                args.password = getpass.getpass()
         except (NoSectionError, NoOptionError) as e:
             print("ERROR! %s found at %s" % (e, AMCREST_CONF))
             return

--- a/man/amcrest-cli.1
+++ b/man/amcrest-cli.1
@@ -38,6 +38,9 @@ Note that when having more than one camera defined, it will be required to use t
 .RS
 $ amcrest-cli --camera mycamera2 --save ~/Desktop/mycamera2_snapshot.jpg
 .RE
+.P
+The password will be prompted to the user if not found in the configuration file.
+.PP
 .SH OPTIONS
 .TP
 .B -h, --help


### PR DESCRIPTION
Allows amcrest-cli to prompt the user for a password if not found in the configuration file. 

```ini
[amcrestcam2]
  hostname: amcrestcam2.example.com
  username: admin
  port: 80
```

```bash
# amcrest-cli  --camera amcrestcam2 --current-time
Password: 
result=2017-03-07 23:01:44
```

This PR slightly changes and fixes the issue #11 which seems to be more effective than encrypting the file. 