### PR TITLE
Allow amcrest-cli to be used with passwords with '%' character.

### DIFF
--- a/cli/amcrest-cli
+++ b/cli/amcrest-cli
@@ -505,7 +505,7 @@ def main():
             args.port = config.getint(section, 'port')
             args.username = config.get(section, 'username')
             try:
-                args.password = config.get(section, 'password')
+                args.password = config.get(section, 'password', raw=True)
             except NoOptionError:
                 args.password = getpass.getpass()
         except (NoSectionError, NoOptionError) as e:


### PR DESCRIPTION
`amcrest-cli` fails to bind user if the password has '%' 

```python
[amcrestcam4]
hostname: 192.168.0.1
username: admin
password: test%123%test
port: 80
```

**Fixes  Issue**:  #76 

**Traceback**:
```bash
Traceback (most recent call last):
  File "/home/mdemello/.virtualenvs/amcrestchime/bin/amcrest-cli", line 960, in <module>
    main()
  File "/home/mdemello/.virtualenvs/amcrestchime/bin/amcrest-cli", line 508, in main
    args.password = config.get(section, 'password')
  File "/usr/lib64/python3.5/configparser.py", line 797, in get
    d)
  File "/usr/lib64/python3.5/configparser.py", line 393, in before_get
    self._interpolate_some(parser, option, L, value, section, defaults, 1)
  File "/usr/lib64/python3.5/configparser.py", line 443, in _interpolate_some
    "found: %r" % (rest,))
configparser.InterpolationSyntaxError: '%' must be followed by '%' or '(', found: "%test%"
```