### PR TITLE
Obfuscated token and password on as_dict() method

### DIFF
--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -111,7 +111,9 @@ class Http(System, Network, MotionDetection, Snapshot,
     def as_dict(self):
         """Callback for __dict__."""
         cdict = self.__dict__.copy()
-        cdict['_token'] = '_redacted'
+        redacted = '**********'
+        cdict['_token'] = redacted
+        cdict['_password'] = redacted
         return cdict
 
     # Base methods


### PR DESCRIPTION
Obfuscated token and password on as_dict() method

```python
In [3]: amcrest.as_dict()
Out[3]: 
{'_authentication': 'digest',
 '_base_url': 'http://amcrestcam2:80/cgi-bin/',
 '_host': 'amcrestcam2',
 '_name': 'LivingRoom\r\n',
 '_password': '**********',
 '_port': 80,
 '_protocol': 'http',
 '_retries_conn': 3,
 '_serial': 'AMCxxxxxxxxxxxx\r\n',
 '_timeout_protocol': 3.0,
 '_token': '**********',
 '_user': 'admin',
 '_verbose': True}
```