### PR TITLE
Makefile.am: Add missing python files

### DIFF
--- a/src/amcrest/Makefile.am
+++ b/src/amcrest/Makefile.am
@@ -34,4 +34,7 @@ pycrest_PYTHON = \
 	log.py \
 	ptz.py \
 	special.py \
+	utils.py \
+	nas.py \
+	storage.py \
 	$(NULL)


### PR DESCRIPTION
It's required to include the storage, utils and nas.
Otherwise, it won't include in the rpm.