### PR TITLE
Update supported models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,8 @@ Supportability Matrix
 +-------------------------+---------------+----------+-----------------+
 | IP3M-941                | Yes           |  working |                 |
 +-------------------------+---------------+----------+-----------------+
-
+| IP3M-HX2                | Yes (partial) |  working |                 |
++-------------------------+---------------+----------+-----------------+
 If you have different model, feel fee to contribute and report your results.
 
 


### PR DESCRIPTION
I have a IP3M-HX2 and have it somewhat working with home assistant on a raspberry pi (an old B+).  I'm pretty impressed with this camera.

I did have some issues with digest auth, but I think that might be more home assistant specific.  The req.raise_for_status didn't appear to be caught by the try/except and were being raised directly to home assistant.

I'm also having some issues I believe because the raspberry pi B+ is underpowered so it might have some issues with the high resolution camera/images.  I have a raspberry pi 3 and will give that a shot in next few days.