### PR TITLE
Fix so that HttpDigestAuth

### DIFF
--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -81,7 +81,7 @@ class Http(System, Network, MotionDetection, Snapshot,
             req = requests.get(url, auth=auth)
             req.raise_for_status()
 
-        except requests.exceptions.HTTPError:
+        except requests.HTTPError:
             # if 401, then try new digest method
             self._authentication = 'digest'
             auth = requests.auth.HTTPDigestAuth(self._user, self._password)
@@ -156,7 +156,7 @@ class Http(System, Network, MotionDetection, Snapshot,
                 )
                 resp.raise_for_status()
                 break
-            except requests.exceptions.HTTPError as error:
+            except requests.HTTPError as error:
                 _LOGGER.debug("Trying again due error %s", error)
                 continue
 


### PR DESCRIPTION
Hi,

I recently purchased an Amcrest IP3M-956B with the intention of accessing the camera through Home Assistant. After some fiddling and extra logging in http.py, I determined that HttpDigestAuth was never attempted due to "requests.exceptions.HTTPError" never beening raised. This pull request seems to handle the exception that is being raised, which allows the script to attempt HttpDigestAuth.

Is there any chance of getting this merged in? If so, let me know if there is anything I can do to clean the PR up. I can then add my camera to the list of supported models, as well as create a PR to home-assistant that implements the previously requested https://github.com/home-assistant/home-assistant/pull/7876.