### PR TITLE
Use unique amcrest exceptions

### DIFF
--- a/src/amcrest/__init__.py
+++ b/src/amcrest/__init__.py
@@ -10,7 +10,7 @@
 # GNU General Public License for more details.
 #
 # vim:sw=4:ts=4:et
-from .exceptions import *
+from .exceptions import AmcrestError, CommError, LoginError
 from .http import Http
 
 

--- a/src/amcrest/__init__.py
+++ b/src/amcrest/__init__.py
@@ -10,8 +10,8 @@
 # GNU General Public License for more details.
 #
 # vim:sw=4:ts=4:et
-
-from amcrest.http import Http
+from .exceptions import *
+from .http import Http
 
 
 class AmcrestCamera(object):

--- a/src/amcrest/exceptions.py
+++ b/src/amcrest/exceptions.py
@@ -6,8 +6,10 @@ This module contains the set of amcrest's exceptions.
 class AmcrestError(Exception):
     """General Amcrest error occurred."""
 
+
 class CommError(AmcrestError):
     """A communication error occurred."""
+
 
 class LoginError(AmcrestError):
     """A login error occurred."""

--- a/src/amcrest/exceptions.py
+++ b/src/amcrest/exceptions.py
@@ -1,0 +1,13 @@
+"""
+amcrest.exceptions
+
+This module contains the set of amcrest's exceptions.
+"""
+class AmcrestError(Exception):
+    """General Amcrest error occurred."""
+
+class CommError(AmcrestError):
+    """A communication error occurred."""
+
+class LoginError(AmcrestError):
+    """A login error occurred."""

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -15,7 +15,7 @@ import logging
 import requests
 from requests.adapters import HTTPAdapter
 
-from .exceptions import *
+from .exceptions import CommError, LoginError
 from .utils import clean_url, pretty
 
 from .audio import Audio


### PR DESCRIPTION
Use amcrest specific exceptions where appropriate, such as for communication and login errors. Use retries and timeouts when generating authentation object. Check for invalid login when using Basic Authentication.