### PR TITLE
Add audio/video enable properties

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,8 +9,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 define([VERSION_MAJOR], [1])
-define([VERSION_MINOR], [2])
-define([VERSION_FIX], [7])
+define([VERSION_MINOR], [3])
+define([VERSION_FIX], [0])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
 define([VERSION_SUFFIX], [_master])
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 
 setup(name='amcrest',
-      version='1.2.7',
+      version='1.3.0',
       description='Python wrapper implementation for Amcrest cameras.',
       long_description=readme(),
       author='Douglas Schilling Landgraf, Marcelo Moreira de Mello',

--- a/src/amcrest/audio.py
+++ b/src/amcrest/audio.py
@@ -12,6 +12,8 @@
 # vim:sw=4:ts=4:et
 import shutil
 
+from . import utils
+
 
 class Audio(object):
 
@@ -113,3 +115,13 @@ class Audio(object):
                 shutil.copyfileobj(ret.raw, out_file)
 
         return ret.raw
+
+    @property
+    def audio_enabled(self):
+        """Return if any audio stream enabled."""
+        return utils.extract_audio_video_enabled('Audio', self.encode_media)
+
+    @audio_enabled.setter
+    def audio_enabled(self, enable):
+        """Enable/disable all audio streams."""
+        self.command(utils.enable_audio_video_cmd('Audio', enable))

--- a/src/amcrest/utils.py
+++ b/src/amcrest/utils.py
@@ -67,3 +67,22 @@ def to_unit(value, unit='B'):
         return (float('{:.{prec}f}'.format(result, prec=PRECISION)), unit)
 
     return value
+
+
+def extract_audio_video_enabled(param, resp):
+    """Extract if any audio/video stream enabled from response."""
+    return 'true' in [part.split('=')[1] for part in resp.split()
+                      if '.{}Enable='.format(param) in part]
+
+
+def enable_audio_video_cmd(param, enable):
+    """Return command to enable/disable all audio/video streams."""
+    cmd = 'configManager.cgi?action=setConfig'
+    formats = [('Extra', 3), ('Main', 4)]
+    if param == 'Video':
+        formats.append(('Snap', 3))
+    for fmt, num in formats:
+        for i in range(num):
+            cmd += '&Encode[0].{}Format[{}].{}Enable={}'.format(
+                fmt, i, param, str(enable).lower())
+    return cmd

--- a/src/amcrest/video.py
+++ b/src/amcrest/video.py
@@ -10,6 +10,7 @@
 # GNU General Public License for more details.
 #
 # vim:sw=4:ts=4:et
+from . import utils
 
 
 class Video(object):
@@ -134,3 +135,21 @@ class Video(object):
             'configManager.cgi?action=getConfig&name=VideoOut'
         )
         return ret.content.decode('utf-8')
+
+    @property
+    def video_enabled(self):
+        """Return if any video stream enabled."""
+        return utils.extract_audio_video_enabled('Video', self.encode_media)
+
+    @video_enabled.setter
+    def video_enabled(self, enable):
+        """Enable/disable all video streams."""
+        self.command(utils.enable_audio_video_cmd('Video', enable))
+        # It's not clear why from the HTTP API SDK doc, but setting InfraRed
+        # to false sets the Night Vision Mode to SmartIR, whereas setting it
+        # to true sets the Night Vision Mode to OFF. Night Vision Mode has a
+        # third setting of Manual, but that must be selected some other way
+        # via the HTTP API.
+        self.command(
+            'configManager.cgi?action=setConfig'
+            '&VideoInOptions[0].InfraRed={}'.format(str(not enable).lower()))


### PR DESCRIPTION
Add properties for determining if any audio/video streams are enabled, and corresponding setters to enable/disable audio/video. Bump version to 1.3.0.