### PR TITLE
Allow Self-Signed Certificates

### DIFF
--- a/src/amcrest/__init__.py
+++ b/src/amcrest/__init__.py
@@ -18,7 +18,7 @@ class AmcrestCamera(object):
     """Amcrest camera object implementation."""
 
     def __init__(self, host, port, user,
-                 password, verbose=True, protocol='http',
+                 password, verbose=True, protocol='http', verify=True,
                  retries_connection=None, timeout_protocol=None):
         super(AmcrestCamera, self).__init__()
         self.camera = Http(
@@ -28,6 +28,7 @@ class AmcrestCamera(object):
             password=password,
             verbose=verbose,
             protocol=protocol,
+            verify=verify,
             retries_connection=retries_connection,
             timeout_protocol=timeout_protocol
         )

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -45,7 +45,7 @@ class Http(System, Network, MotionDetection, Snapshot,
            Log, Ptz, Special, Storage, Nas):
 
     def __init__(self, host, port, user,
-                 password, verbose=True, protocol='http', verify=True,
+                 password, verbose=True, protocol='http', ssl_verify=True,
                  retries_connection=None, timeout_protocol=None):
 
         self._token_lock = threading.Lock()
@@ -55,7 +55,7 @@ class Http(System, Network, MotionDetection, Snapshot,
         self._password = password
         self._verbose = verbose
         self._protocol = protocol
-        self._verify = verify
+        self._verify = ssl_verify
         self._base_url = self.__base_url()
 
         self._retries_default = (

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -45,7 +45,7 @@ class Http(System, Network, MotionDetection, Snapshot,
            Log, Ptz, Special, Storage, Nas):
 
     def __init__(self, host, port, user,
-                 password, verbose=True, protocol='http',
+                 password, verbose=True, protocol='http', verify=True,
                  retries_connection=None, timeout_protocol=None):
 
         self._token_lock = threading.Lock()
@@ -55,6 +55,7 @@ class Http(System, Network, MotionDetection, Snapshot,
         self._password = password
         self._verbose = verbose
         self._protocol = protocol
+        self._verify = verify
         self._base_url = self.__base_url()
 
         self._retries_default = (
@@ -139,6 +140,7 @@ class Http(System, Network, MotionDetection, Snapshot,
 
     def _command(self, cmd, retries=None, timeout_cmd=None, stream=False):
         session = requests.Session()
+        session.verify = self._verify
         url = self.__base_url(cmd)
         if retries is None:
             retries = self._retries_default


### PR DESCRIPTION
This will allow user's to disable SSL Certificate verification.

Use-case: You don't want to jump through hurdles of creating valid certificates but you still want to make use of HTTPS security so you don't send passwords in the clear.