### PR TITLE
Unset the token when there's a communication error generating it

### DIFF
--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -89,6 +89,9 @@ class Http(System, Network, MotionDetection, Snapshot,
             except LoginError as error:
                 self._token = None
                 raise error
+        except CommError:
+            self._token = None
+            raise
 
         # check if user passed
         result = resp.lower()


### PR DESCRIPTION
If the camera gives a CommError (for example because it's not reachable)
when calling _generate_token, the _token should be unset, as otherwise
the token will be reused for every command and it won't be (re)generated
correctly when the camera is back online.