### PR TITLE
Allows CLI to run on Windows

### DIFF
--- a/cli/amcrest-cli
+++ b/cli/amcrest-cli
@@ -31,7 +31,10 @@ except ImportError:
 
 from amcrest import AmcrestCamera
 
-AMCREST_CONF = os.path.join(os.getenv("HOME"), '.config/amcrest.conf')
+if os.name == 'nt':
+    AMCREST_CONF = os.path.join(os.getenv("HOMEPATH"), '.config\\amcrest.conf')
+else:
+    AMCREST_CONF = os.path.join(os.getenv("HOME"), '.config/amcrest.conf')
 
 
 def graceful_exit(_signo, _stack_frame):


### PR DESCRIPTION
This change adapts the computation of the path to the config file so it works on Windows and is functionally equivalent.