### PR TITLE
Fixed inconsistency with Http() "ssl_verify" property name

### DIFF
--- a/src/amcrest/__init__.py
+++ b/src/amcrest/__init__.py
@@ -28,7 +28,7 @@ class AmcrestCamera(object):
             password=password,
             verbose=verbose,
             protocol=protocol,
-            verify=verify,
+            ssl_verify=verify,
             retries_connection=retries_connection,
             timeout_protocol=timeout_protocol
         )


### PR DESCRIPTION
Replaced wrong property name "verify=verify" with coherent "ssl_verify=verify"