### PR TITLE
Added get_event_stream() to allow real time streaming of camera events

### DIFF
--- a/src/amcrest/special.py
+++ b/src/amcrest/special.py
@@ -155,8 +155,9 @@ class Special(object):
                 raise CommError(error)
 
         return ret.raw
-        
-    def get_event_stream(self, eventcode='VideoMotion', callback=None, timeout=(TIMEOUT_HTTP_PROTOCOL,3600*24*365)):
+
+    def get_event_stream(self, eventcode='VideoMotion', callback=None,
+                         timeout=(TIMEOUT_HTTP_PROTOCOL, 3600*24*365)):
         """
         Params:
         eventcode:
@@ -172,11 +173,11 @@ class Special(object):
         StorageFailure: storage failure event
         StorageLowSpace: storage low space event
         AlarmOutput: alarm output event
-        
+
         callback:
         function to use to process data when running in a Thread
         event data is passed as the first argument
-        
+
         timeout:
         int or tuple, requests timeout format
         no-data timeout, set to a long value for streaming
@@ -187,16 +188,19 @@ class Special(object):
                 stream=True,
                 timeout_cmd=timeout
             )
-            if ret.encoding is None: ret.encoding = 'utf-8' #stupid thing required by requests when streaming
+            if ret.encoding is None:
+                ret.encoding = 'utf-8'  #required by requests when streaming
             while True:
                 for line in ret.iter_lines(3, decode_unicode=True):
                     if line.lower().startswith('content-length'):
-                        content_length = int(''.join(x for x in line if x.isdigit()))
-                        #: pause the generator
+                        cont_len = int(''.join(x for x in line
+                                               if x.isdigit()))
+                        # pause the generator
                         break
-                            
-                #: Continue the generator and read the exact amount of the body (plus 2 as there are 2 returns included).        
-                for text in ret.iter_content(content_length+2, decode_unicode=True): 
+
+                # Continue the generator and read the exact amount of the body
+                # (plus 2 as there are 2 returns included).
+                for text in ret.iter_content(cont_len+2, decode_unicode=True):
                     if callback:
                         callback(text.strip())
                     else:


### PR DESCRIPTION
Added a new method `get_event_stream(eventcode='VideoMotion', callback, timeout)`

Default eventcode is `VideoMotion`, this is a string and can be a comma separated list of event codes (no spaces allowed).
`callback` is optional, and is intended for when this method is used in a `Thread` (the best way to use it). The method will never return (unless there is an error or timeout) if callback is given. The events (string) are passed as the first argument to `callback`.

`timeout` is optional, and is a standard `requests` int, float or tuple. If not given, the default connect timeout is used, and the streaming timeout is 1 year.

If no `callback` is given, the method will return the first `eventcode` string detected, if that occurs before `timeout` has elapsed. If `timeout` occurs first, `None` is returned (as it is for an error).

Example events look like:
```
Code=VideoMotion;action=Start;index=0;data={
   "RegionName" : [ "Region1", "Region2" ]
}
Code=VideoMotion|action=Stop|index=0|data={
   "RegionName" : [ "Region1", "Region2" ]
}
Code=AlarmLocal;action=Start;index=0;data={
   "EventID" : 1850153,
   "PTS" : 43326212790.0,
   "SenseMethod" : "",
   "UTC" : 1578657901.0
}
```
Which can be parsed in `callback`.

Example use:
```
#!/usr/bin/env python3

#Amcrest camera motion detection

from amcrest import AmcrestCamera
from threading import Thread
import time

def cb(text):
    #process events
    print(text)

camera = AmcrestCamera('192.168.100.125', 80, 'admin', 'xxxxxxxxx').camera

try:
    _events = Thread(target=camera.get_event_stream, args=('VideoMotion', cb), daemon=True)
    _events.start()
    while True:
        #do other stuff
        time.sleep(60)
    
except KeyboardInterrupt:
    print('exited')
```