### PR TITLE
Add is_alarm_triggered to check for AlarmLocal events

### DIFF
--- a/src/amcrest/event.py
+++ b/src/amcrest/event.py
@@ -145,6 +145,11 @@ class Event(object):
         return True
 
     @property
+    def is_alarm_triggered(self):
+        event = self.event_channels_happened('AlarmLocal')
+        return bool('channels' in event)
+
+    @property
     def event_management(self):
         ret = self.command(
             'eventManager.cgi?action=getCaps'


### PR DESCRIPTION
Helper function to check for AlarmLocal condition.  AlarmLocal is similar to the VideoMotion event but triggers on what the camera considers a local alarm rather than just video motion. For the Amcrest AD110 Video Doorbell, AlarmLocal seems to be what's used for it's combined PIR motion + VideoMotion alerts that are sent to the smartphone app.  VideoMotion is too noisy and triggers any time there is enough motion in the video image itself, without needing any actual PIR-triggered motion.