### PR TITLE
Add event_stream() which returns stream of camera events

### DIFF
--- a/src/amcrest/config.py
+++ b/src/amcrest/config.py
@@ -13,8 +13,13 @@
 
 # How long to wait for the server send data before giving up, as a float
 # or a (connect timeout, read timeout) tuple.
-# Default value from requests library is 3
-TIMEOUT_HTTP_PROTOCOL = 3.0
+# requests library suggests a value slightly larger than a multiple of 3.
+TIMEOUT_HTTP_PROTOCOL = 6.05
+
+# Socket TCP keep alive parameters.
+KEEPALIVE_IDLE = 20
+KEEPALIVE_INTERVAL = 10
+KEEPALIVE_COUNT = 5
 
 # Retries - maximum number of retries each connection should attempt
 # Default value from requests library is 3

--- a/src/amcrest/event.py
+++ b/src/amcrest/event.py
@@ -21,12 +21,12 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _event_lines(ret):
-    line = ''
+    line = ""
     for char in ret.iter_content(decode_unicode=True):
         line = line + char
-        if line.endswith('\r\n'):
+        if line.endswith("\r\n"):
             yield line.strip()
-            line = ''
+            line = ""
 
 
 class Event(object):
@@ -193,21 +193,21 @@ class Event(object):
         except TypeError:
             timeout_cmd = (self._timeout_default, None)
         ret = self.command(
-            'eventManager.cgi?action=attach&codes=[{0}]'.format(eventcodes),
+            "eventManager.cgi?action=attach&codes=[{0}]".format(eventcodes),
             timeout_cmd=timeout_cmd,
-            stream=True
+            stream=True,
         )
         if ret.encoding is None:
-            ret.encoding = 'utf-8'
-
+            ret.encoding = "utf-8"
         try:
             for line in _event_lines(ret):
-                if line.lower().startswith('content-length:'):
-                    chunk_size = int(line.split(':')[1])
-                    yield next(ret.iter_content(
-                        chunk_size=chunk_size, decode_unicode=True))
+                if line.lower().startswith("content-length:"):
+                    chunk_size = int(line.split(":")[1])
+                    yield next(
+                        ret.iter_content(chunk_size=chunk_size, decode_unicode=True)
+                    )
         except (RequestException, HTTPError) as error:
-            _LOGGER.debug('%s Error during event streaming: %r', self, error)
+            _LOGGER.debug("%s Error during event streaming: %r", self, error)
             raise CommError(error)
         finally:
             ret.close()

--- a/src/amcrest/event.py
+++ b/src/amcrest/event.py
@@ -192,10 +192,13 @@ class Event(object):
         if not any(isinstance(x, NoHeaderErrorFilter) for x in urllib3_logger.filters):
             urllib3_logger.addFilter(NoHeaderErrorFilter())
 
+        # Remove read timeout since there's no telling when, if ever,
+        # an event will come.
         try:
             timeout_cmd = (self._timeout_default[0], None)
         except TypeError:
             timeout_cmd = (self._timeout_default, None)
+
         ret = self.command(
             "eventManager.cgi?action=attach&codes=[{0}]".format(eventcodes),
             timeout_cmd=timeout_cmd,
@@ -203,6 +206,7 @@ class Event(object):
         )
         if ret.encoding is None:
             ret.encoding = "utf-8"
+
         try:
             for line in _event_lines(ret):
                 if line.lower().startswith("content-length:"):

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -12,9 +12,12 @@
 # vim:sw=4:ts=4:et
 import logging
 import re
+import socket
 import threading
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.connection import HTTPConnection
 
 from .exceptions import CommError, LoginError
 from .utils import clean_url, pretty
@@ -35,9 +38,34 @@ from .system import System
 from .user_management import UserManagement
 from .video import Video
 
-from .config import TIMEOUT_HTTP_PROTOCOL, MAX_RETRY_HTTP_CONNECTION
+from .config import (
+    KEEPALIVE_COUNT,
+    KEEPALIVE_IDLE,
+    KEEPALIVE_INTERVAL,
+    MAX_RETRY_HTTP_CONNECTION,
+    TIMEOUT_HTTP_PROTOCOL,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+_KEEPALIVE_OPTS = HTTPConnection.default_socket_options + [
+    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, KEEPALIVE_IDLE),
+    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, KEEPALIVE_INTERVAL),
+    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, KEEPALIVE_COUNT),
+]
+
+
+class SOHTTPAdapter(HTTPAdapter):
+    """HTTPAdapter with support for socket options."""
+    def __init__(self, *args, **kwargs):
+        self.socket_options = kwargs.pop("socket_options", None)
+        super(SOHTTPAdapter, self).__init__(*args, **kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        if self.socket_options is not None:
+            kwargs["socket_options"] = self.socket_options
+        super(SOHTTPAdapter, self).init_poolmanager(*args, **kwargs)
 
 
 # pylint: disable=too-many-ancestors
@@ -121,7 +149,7 @@ class Http(System, Network, MotionDetection, Snapshot,
     def get_base_url(self):
         return self._base_url
 
-    def command(self, cmd, retries=None, timeout_cmd=None, stream=False):
+    def command(self, *args, **kwargs):
         """
         Args:
             cmd - command to execute via http
@@ -132,7 +160,7 @@ class Http(System, Network, MotionDetection, Snapshot,
         with self._token_lock:
             if not self._token:
                 self._generate_token()
-        return self._command(cmd, retries, timeout_cmd, stream)
+        return self._command(*args, **kwargs)
 
     def _command(self, cmd, retries=None, timeout_cmd=None, stream=False):
         url = self.__base_url(cmd)
@@ -141,32 +169,43 @@ class Http(System, Network, MotionDetection, Snapshot,
         _LOGGER.debug("%s HTTP query %i: %s", self, cmd_id, url)
         if retries is None:
             retries = self._retries_default
-        for loop in range(1, 2 + retries):
-            _LOGGER.debug("%s Running query %i attempt %s", self, cmd_id, loop)
+        timeout = timeout_cmd or self._timeout_default
+        with requests.Session() as session:
             try:
-                resp = requests.get(
-                    url,
-                    auth=self._token,
-                    stream=stream,
-                    timeout=timeout_cmd or self._timeout_default,
-                    verify=self._verify,
+                use_keepalive = timeout[0] is None or timeout[1] is None
+            except TypeError:
+                use_keepalive = timeout is None
+            if use_keepalive:
+                session.mount(
+                    "{0}://".format(self._protocol),
+                    SOHTTPAdapter(socket_options=_KEEPALIVE_OPTS),
                 )
-                if resp.status_code == 401:
+            for loop in range(1, 2 + retries):
+                _LOGGER.debug("%s Running query %i attempt %s", self, cmd_id, loop)
+                try:
+                    resp = session.get(
+                        url,
+                        auth=self._token,
+                        stream=stream,
+                        timeout=timeout,
+                        verify=self._verify,
+                    )
+                    if resp.status_code == 401:
+                        _LOGGER.debug(
+                            "%s Query %i: Unauthorized (401)", self, cmd_id)
+                        self._token = None
+                        raise LoginError
+                    resp.raise_for_status()
+                except requests.RequestException as error:
                     _LOGGER.debug(
-                        "%s Query %i: Unauthorized (401)", self, cmd_id)
-                    self._token = None
-                    raise LoginError
-                resp.raise_for_status()
-            except requests.RequestException as error:
-                _LOGGER.debug(
-                    "%s Query %i failed due to error: %r", self, cmd_id, error)
-                if loop > retries:
-                    raise CommError(error)
-                msg = re.sub(r'at 0x[0-9a-fA-F]+', 'at ADDRESS', repr(error))
-                _LOGGER.warning("%s Trying again due to error: %s", self, msg)
-                continue
-            else:
-                break
+                        "%s Query %i failed due to error: %r", self, cmd_id, error)
+                    if loop > retries:
+                        raise CommError(error)
+                    msg = re.sub(r'at 0x[0-9a-fA-F]+', 'at ADDRESS', repr(error))
+                    _LOGGER.warning("%s Trying again due to error: %s", self, msg)
+                    continue
+                else:
+                    break
 
         _LOGGER.debug("%s Query %i worked. Exit code: <%s>",
                       self, cmd_id, resp.status_code)


### PR DESCRIPTION
## Description
Currently, determining if motion or other events occur requires polling via `event_channels_happened()` (or one of the other methods or properties that use it.) This can delay response to events, and can even miss events if the event duration is shorter than the polling period.

This adds a new method -- `event_stream()` -- which will return events as they happen. It is a generator and will normally not return, so it should be run in a separate thread or process.

## Example use case
```python
import re
import threading
from amcrest import AmcrestCamera, CommError

_START_STOP = re.compile(r"Code=([^;]+);action=(Start|Stop)", flags=re.S)

def process_events(camera, event_codes):
    event_codes = ",".join(event_codes)
    while True:
        try:
            for event_info in camera.event_stream(event_codes, retries=5):
                print("Event info:", repr(event_info))
                for code, action in _START_STOP.findall(event_info):
                    print("--->", code, action)
        except CommError as error:
            print("Error while processing events:", repr(error))

camera = AmcrestCamera(...).camera
thread = threading.Thread(target=process_events, args=(camera, ["VideoMotion"]))
thread.daemon = True
thread.start()
```
## To do
- [x] Make sure comm errors and camera power cycling are handled properly.
- [x] Get feedback from other users with other camera models and/or firmware versions.
- [x] Prototype usage in Home Assistant's amcrest integration.
- [x] Determine if anything can be done about urllib3 warning:
```
WARNING:urllib3.connectionpool:Failed to parse headers (url=http://<host>:<port>/cgi-bin/eventManager.cgi?action=attach&codes=%5BVideoMotion%5D): [StartBoundaryNotFoundDefect(), MultipartInvariantViolationDefect()], unparsed data: ''
Traceback (most recent call last):
  File "/home/phil/test/amcrest/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 441, in _make_request
    assert_header_parsing(httplib_response.msg)
  File "/home/phil/test/amcrest/venv/lib/python3.7/site-packages/urllib3/util/response.py", line 71, in assert_header_parsing
    raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)
urllib3.exceptions.HeaderParsingError: [StartBoundaryNotFoundDefect(), MultipartInvariantViolationDefect()], unparsed data: ''
```

Thanks to @NickWaterton and his groundwork in PR #140!