### PR TITLE
Added ability for configuring auto reboot.

### DIFF
--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -48,12 +48,12 @@ from .config import (
 
 _LOGGER = logging.getLogger(__name__)
 
-_KEEPALIVE_OPTS = HTTPConnection.default_socket_options + [
+_KEEPALIVE_OPTS = HTTPConnection.default_socket_options + list(filter(lambda option: option[1], [
     (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, KEEPALIVE_IDLE),
+    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE if hasattr(socket, "TCP_KEEPIDLE") else None, KEEPALIVE_IDLE), # TCP_KEEPIDLE doesn't exist for Mac
     (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, KEEPALIVE_INTERVAL),
     (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, KEEPALIVE_COUNT),
-]
+]))
 
 
 class SOHTTPAdapter(HTTPAdapter):

--- a/src/amcrest/system.py
+++ b/src/amcrest/system.py
@@ -12,6 +12,7 @@
 #
 # vim:sw=4:ts=4:et
 
+import datetime
 
 class System(object):
     """Amcrest system class."""
@@ -47,6 +48,14 @@ class System(object):
     def __get_config(self, config_name):
         ret = self.command(
             'configManager.cgi?action=getConfig&name={0}'.format(config_name)
+        )
+        return ret.content.decode('utf-8')
+
+    def __set_config(self, *argv):
+        config_strs = "&".join(map(lambda pair: str(pair[0]) + "=" + str(pair[1]), argv))
+        print('configManager.cgi?action=setConfig&{0}'.format(config_strs))
+        ret = self.command(
+            'configManager.cgi?action=setConfig&{0}'.format(config_strs)
         )
         return ret.content.decode('utf-8')
 
@@ -165,3 +174,16 @@ class System(object):
 
         ret = self.command(cmd)
         return ret.content.decode('utf-8')
+
+    def setAutoReboot(self, date, everyday=False):
+        # No reboot
+        if date is None:
+            return self.__set_config(("AutoMaintain.AutoRebootDay", -1))
+        assert isinstance(date, datetime.datetime)
+        date_info = date.timetuple()
+        config = {
+            "AutoMaintain.AutoRebootDay": 7 if everyday else date.isoweekday(),
+            "AutoMaintain.AutoRebootHour": date_info.tm_hour,
+            "AutoMaintain.AutoRebootMinute": date_info.tm_min
+        }
+        return self.__set_config(*config.items())


### PR DESCRIPTION
Added ability for configuring auto reboot using API v3 of 2017 page 82. Tested with IP2M-841B. I want this ability so I can write a script to continuously configure the device's reboot time to be **X** mins in the future. This is for cases where the device's networking crashes between now and **X** mins in the future , it can immediately reboot and come back online. 