### PR TITLE
FIX for #75 and #149

### DIFF
--- a/src/amcrest/audio.py
+++ b/src/amcrest/audio.py
@@ -37,7 +37,7 @@ class Audio(object):
         return ret.content.decode('utf-8')
 
     def play_wav(self, httptype=None, channel=None,
-                 path_file=None):
+                 path_file=None, encoding='G.711A'):
 
         if httptype is None:
             httptype = 'singlepart'
@@ -48,7 +48,7 @@ class Audio(object):
         if path_file is None:
             raise RuntimeError('filename is required')
 
-        self.audio_send_stream(httptype, channel, path_file, 'G.711A')
+        self.audio_send_stream(httptype, channel, path_file, encoding)
 
     def audio_send_stream(self, httptype=None,
                           channel=None, path_file=None, encode=None):


### PR DESCRIPTION
Potential fix for #75 and #149

I do not have access to the hardware at this time (due to corona virus). So I cannot test this. 

The user using play_wav will now need to know the encoding type for their .wav file. 

The most critical part of this PR is the new optional argument 'encoding'

It is up to someone who has access to a camera to test out all the encodings and report back to this community their results. 

According to a comment in the same file:

`            Supported audio encode type according with documentation:
                PCM
                ADPCM
                G.711A
                G.711.Mu
                G.726
                G.729
                MPEG2
                AMR
                AAC`

  G.711A will be the default one as that was the encoding type that was hard coded before. 

Take care, and happy testing!
