### PR TITLE
Add exceptions.py and media.py to the python3-amcrest rpm build.

### DIFF
--- a/src/amcrest/Makefile.am
+++ b/src/amcrest/Makefile.am
@@ -37,4 +37,6 @@ pycrest_PYTHON = \
 	utils.py \
 	nas.py \
 	storage.py \
+	exceptions.py \
+	media.py \
 	$(NULL)


### PR DESCRIPTION
After installing I hit the below two errors when executing amcrest-cli due to missing files.

$ amcrest-cli --help
Traceback (most recent call last):
  File "/usr/bin/amcrest-cli", line 34, in <module>
    from amcrest import AmcrestCamera
  File "/usr/lib/python3.8/site-packages/amcrest/__init__.py", line 13, in <module>
    from .exceptions import AmcrestError, CommError, LoginError  # noqa: F401
ModuleNotFoundError: No module named 'amcrest.exceptions'

$ amcrest-cli --help
Traceback (most recent call last):
  File "/usr/bin/amcrest-cli", line 34, in <module>
    from amcrest import AmcrestCamera
  File "/usr/lib/python3.8/site-packages/amcrest/__init__.py", line 14, in <module>
    from .http import Http
  File "/usr/lib/python3.8/site-packages/amcrest/http.py", line 28, in <module>
    from .media import Media
ModuleNotFoundError: No module named 'amcrest.media'