### PR TITLE
Add functionality to use additional channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Vim temporary files
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
     - python: "3.7"
       env: TOXENV=py37
       dist: xenial
+    - python: "3.8"
+      env: TOXENV=py38
+    - python: "3.9"
+      env: TOXENV=py39
 cache: pip
 install: pip install -U tox coveralls
 script: tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ description-file = README.rst
 [tool:pytest]
 testpaths = tests
 norecursedirs = .git
+
+[flake8]
+max-line-length = 79

--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,7 @@ setup(name='amcrest',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
       ])

--- a/src/amcrest/__init__.py
+++ b/src/amcrest/__init__.py
@@ -17,9 +17,18 @@ from .http import Http
 class AmcrestCamera(object):
     """Amcrest camera object implementation."""
 
-    def __init__(self, host, port, user,
-                 password, verbose=True, protocol='http', ssl_verify=True,
-                 retries_connection=None, timeout_protocol=None):
+    def __init__(
+        self,
+        host,
+        port,
+        user,
+        password,
+        verbose=True,
+        protocol="http",
+        ssl_verify=True,
+        retries_connection=None,
+        timeout_protocol=None,
+    ):
         super(AmcrestCamera, self).__init__()
         self.camera = Http(
             host=host,
@@ -30,5 +39,5 @@ class AmcrestCamera(object):
             protocol=protocol,
             ssl_verify=ssl_verify,
             retries_connection=retries_connection,
-            timeout_protocol=timeout_protocol
+            timeout_protocol=timeout_protocol,
         )

--- a/src/amcrest/audio.py
+++ b/src/amcrest/audio.py
@@ -21,37 +21,34 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Audio(object):
-
     @property
     def audio_input_channels_numbers(self):
-        ret = self.command(
-            'devAudioInput.cgi?action=getCollect'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("devAudioInput.cgi?action=getCollect")
+        return ret.content.decode("utf-8")
 
     @property
     def audio_output_channels_numbers(self):
-        ret = self.command(
-            'devAudioOutput.cgi?action=getCollect'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("devAudioOutput.cgi?action=getCollect")
+        return ret.content.decode("utf-8")
 
-    def play_wav(self, httptype=None, channel=None,
-                 path_file=None, encoding='G.711A'):
+    def play_wav(
+        self, httptype=None, channel=None, path_file=None, encoding="G.711A"
+    ):
 
         if httptype is None:
-            httptype = 'singlepart'
+            httptype = "singlepart"
 
         if channel is None:
-            channel = '1'
+            channel = "1"
 
         if path_file is None:
-            raise RuntimeError('filename is required')
+            raise RuntimeError("filename is required")
 
         self.audio_send_stream(httptype, channel, path_file, encoding)
 
-    def audio_send_stream(self, httptype=None,
-                          channel=None, path_file=None, encode=None):
+    def audio_send_stream(
+        self, httptype=None, channel=None, path_file=None, encode=None
+    ):
         """
         Params:
 
@@ -79,23 +76,25 @@ class Audio(object):
             raise RuntimeError("Requires htttype and channel")
 
         file_audio = {
-            'file': open(path_file, 'rb'),
+            "file": open(path_file, "rb"),
         }
 
         header = {
-            'content-type': 'Audio/' + encode,
-            'content-length': '9999999'
+            "content-type": "Audio/" + encode,
+            "content-length": "9999999",
         }
 
         self.command_audio(
-            'audio.cgi?action=postAudio&httptype={0}&channel={1}'.format(
-                httptype, channel),
+            "audio.cgi?action=postAudio&httptype={0}&channel={1}".format(
+                httptype, channel
+            ),
             file_content=file_audio,
-            http_header=header
+            http_header=header,
         )
 
-    def audio_stream_capture(self, httptype=None,
-                             channel=None, path_file=None):
+    def audio_stream_capture(
+        self, httptype=None, channel=None, path_file=None
+    ):
         """
         Params:
 
@@ -112,17 +111,22 @@ class Audio(object):
             raise RuntimeError("Requires htttype and channel")
 
         ret = self.command(
-            'audio.cgi?action=getAudio&httptype={0}&channel={1}'.format(
-                httptype, channel), stream=True)
+            "audio.cgi?action=getAudio&httptype={0}&channel={1}".format(
+                httptype, channel
+            ),
+            stream=True,
+        )
 
         if path_file:
             try:
-                with open(path_file, 'wb') as out_file:
+                with open(path_file, "wb") as out_file:
                     shutil.copyfileobj(ret.raw, out_file)
             except HTTPError as error:
                 _LOGGER.debug(
                     "%s Audio stream capture to file failed due to error: %s",
-                    self, repr(error))
+                    self,
+                    repr(error),
+                )
                 raise CommError(error)
 
         return ret.raw
@@ -130,9 +134,9 @@ class Audio(object):
     @property
     def audio_enabled(self):
         """Return if any audio stream enabled."""
-        return utils.extract_audio_video_enabled('Audio', self.encode_media)
+        return utils.extract_audio_video_enabled("Audio", self.encode_media)
 
     @audio_enabled.setter
     def audio_enabled(self, enable):
         """Enable/disable all audio streams."""
-        self.command(utils.enable_audio_video_cmd('Audio', enable))
+        self.command(utils.enable_audio_video_cmd("Audio", enable))

--- a/src/amcrest/audio.py
+++ b/src/amcrest/audio.py
@@ -98,14 +98,12 @@ class Audio(object):
         """
         Params:
 
-            path_file - path to output file
-            channel: - integer
             httptype - type string (singlepart or multipart)
-
                 singlepart: HTTP content is a continuos flow of audio packets
                 multipart: HTTP content type is multipart/x-mixed-replace, and
                            each audio packet ends with a boundary string
-
+            channel - integer
+            path_file - path to output file
         """
         if httptype is None and channel is None:
             raise RuntimeError("Requires htttype and channel")
@@ -131,12 +129,23 @@ class Audio(object):
 
         return ret.raw
 
+    def is_audio_enabled(self, channel):
+        """Return if any audio stream enabled on the given channel."""
+        is_enabled = utils.extract_audio_video_enabled(
+            "Audio", self.encode_media
+        )
+        return is_enabled[channel]
+
+    def set_audio_enabled(self, enable, channel):
+        """Enable/disable all audio streams on given channel."""
+        self.command(utils.enable_audio_video_cmd("Audio", enable, channel))
+
     @property
     def audio_enabled(self):
         """Return if any audio stream enabled."""
-        return utils.extract_audio_video_enabled("Audio", self.encode_media)
+        return self.is_audio_enabled(channel=0)
 
     @audio_enabled.setter
     def audio_enabled(self, enable):
         """Enable/disable all audio streams."""
-        self.command(utils.enable_audio_video_cmd("Audio", enable))
+        self.set_audio_enabled(enable, channel=0)

--- a/src/amcrest/event.py
+++ b/src/amcrest/event.py
@@ -24,6 +24,7 @@ _REG_PARSE_MALFORMED_JSON = re.compile(
     r'(?P<key>"[^"\\]*(?:\\.[^"\\]*)*"|[^\s"]+)\s:\s(?P<value>"[^"\\]*(?:\\.[^"\\]*)*"|[^\s"]+)'
 )
 
+
 def _event_lines(ret):
     line = ""
     for char in ret.iter_content(decode_unicode=True):
@@ -34,110 +35,95 @@ def _event_lines(ret):
 
 
 class Event(object):
-
     def event_handler_config(self, handlername):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name={0}'.format(handlername)
+            "configManager.cgi?action=getConfig&name={0}".format(handlername)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def alarm_config(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=Alarm'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=Alarm")
+        return ret.content.decode("utf-8")
 
     @property
     def alarm_out_config(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=AlarmOut'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=AlarmOut")
+        return ret.content.decode("utf-8")
 
     @property
     def alarm_input_channels(self):
-        ret = self.command(
-            'alarm.cgi?action=getInSlots'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("alarm.cgi?action=getInSlots")
+        return ret.content.decode("utf-8")
 
     @property
     def alarm_output_channels(self):
-        ret = self.command(
-            'alarm.cgi?action=getOutSlots'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("alarm.cgi?action=getOutSlots")
+        return ret.content.decode("utf-8")
 
     @property
     def alarm_states_input_channels(self):
-        ret = self.command(
-            'alarm.cgi?action=getInState'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("alarm.cgi?action=getInState")
+        return ret.content.decode("utf-8")
 
     @property
     def alarm_states_output_channels(self):
-        ret = self.command(
-            'alarm.cgi?action=getOutState'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("alarm.cgi?action=getOutState")
+        return ret.content.decode("utf-8")
 
     @property
     def video_blind_detect_config(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=BlindDetect'
+            "configManager.cgi?action=getConfig&name=BlindDetect"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def video_loss_detect_config(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=LossDetect'
+            "configManager.cgi?action=getConfig&name=LossDetect"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def event_login_failure(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=LoginFailureAlarm'
+            "configManager.cgi?action=getConfig&name=LoginFailureAlarm"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def event_storage_not_exist(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=StorageNotExist'
+            "configManager.cgi?action=getConfig&name=StorageNotExist"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def event_storage_access_failure(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=StorageFailure'
+            "configManager.cgi?action=getConfig&name=StorageFailure"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def event_storage_low_space(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=StorageLowSpace'
+            "configManager.cgi?action=getConfig&name=StorageLowSpace"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def event_net_abort(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=NetAbort'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=NetAbort")
+        return ret.content.decode("utf-8")
 
     @property
     def event_ip_conflict(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=IPConflict'
+            "configManager.cgi?action=getConfig&name=IPConflict"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def event_channels_happened(self, eventcode):
         """
@@ -155,43 +141,42 @@ class Event(object):
         SmartMotionVehicle: vehicle detection event
         """
         ret = self.command(
-            'eventManager.cgi?action=getEventIndexes&code={0}'.format(
-                eventcode)
+            "eventManager.cgi?action=getEventIndexes&code={0}".format(
+                eventcode
+            )
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def is_motion_detected(self):
-        event = self.event_channels_happened('VideoMotion')
-        if 'channels' not in event:
+        event = self.event_channels_happened("VideoMotion")
+        if "channels" not in event:
             return False
         return True
 
     @property
     def is_alarm_triggered(self):
-        event = self.event_channels_happened('AlarmLocal')
-        return bool('channels' in event)
+        event = self.event_channels_happened("AlarmLocal")
+        return bool("channels" in event)
 
     @property
     def is_human_detected(self):
-        event = self.event_channels_happened('SmartMotionHuman')
-        if 'channels' not in event:
+        event = self.event_channels_happened("SmartMotionHuman")
+        if "channels" not in event:
             return False
         return True
 
     @property
     def is_vehicle_detected(self):
-        event = self.event_channels_happened('SmartMotionVehicle')
-        if 'channels' not in event:
+        event = self.event_channels_happened("SmartMotionVehicle")
+        if "channels" not in event:
             return False
         return True
 
     @property
     def event_management(self):
-        ret = self.command(
-            'eventManager.cgi?action=getCaps'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("eventManager.cgi?action=getCaps")
+        return ret.content.decode("utf-8")
 
     def event_stream(self, eventcodes, retries=None, timeout_cmd=None):
         """
@@ -211,7 +196,9 @@ class Event(object):
         SmartMotionVehicle: vehicle detection event
         """
         urllib3_logger = logging.getLogger("urllib3.connectionpool")
-        if not any(isinstance(x, NoHeaderErrorFilter) for x in urllib3_logger.filters):
+        if not any(
+            isinstance(x, NoHeaderErrorFilter) for x in urllib3_logger.filters
+        ):
             urllib3_logger.addFilter(NoHeaderErrorFilter())
 
         # If timeout is not specified, then use default, but remove read timeout since
@@ -236,7 +223,9 @@ class Event(object):
                 if line.lower().startswith("content-length:"):
                     chunk_size = int(line.split(":")[1])
                     yield next(
-                        ret.iter_content(chunk_size=chunk_size, decode_unicode=True)
+                        ret.iter_content(
+                            chunk_size=chunk_size, decode_unicode=True
+                        )
                     )
         except (RequestException, HTTPError) as error:
             _LOGGER.debug("%s Error during event streaming: %r", self, error)
@@ -249,24 +238,27 @@ class Event(object):
         for event_info in self.event_stream(eventcodes, retries, timeout_cmd):
             _LOGGER.debug("%s event info: %r", self, event_info)
             payload = dict()
-            for Key, Value \
-                    in _REG_PARSE_KEY_VALUE.findall(
-                            event_info.strip().replace('\n', '')
-                        ):
-                if Key == 'data':
+            for Key, Value in _REG_PARSE_KEY_VALUE.findall(
+                event_info.strip().replace("\n", "")
+            ):
+                if Key == "data":
                     tmpData = dict()
-                    for DataKey, DataValue \
-                            in _REG_PARSE_MALFORMED_JSON.findall(Value):
-                        tmpData[DataKey.replace('"', '')] = \
-                                    DataValue.replace('"', '')
+                    for (
+                        DataKey,
+                        DataValue,
+                    ) in _REG_PARSE_MALFORMED_JSON.findall(Value):
+                        tmpData[DataKey.replace('"', "")] = DataValue.replace(
+                            '"', ""
+                        )
                     Value = tmpData
                 payload[Key] = Value
             _LOGGER.debug(
                 "%s generate new event, code: %s , payload: %s",
-                self, payload['Code'], payload
+                self,
+                payload["Code"],
+                payload,
             )
-            yield payload['Code'], payload
-
+            yield payload["Code"], payload
 
 
 class NoHeaderErrorFilter(logging.Filter):

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -64,6 +64,7 @@ except AttributeError:
 
 class SOHTTPAdapter(HTTPAdapter):
     """HTTPAdapter with support for socket options."""
+
     def __init__(self, *args, **kwargs):
         self.socket_options = kwargs.pop("socket_options", None)
         super(SOHTTPAdapter, self).__init__(*args, **kwargs)
@@ -75,13 +76,35 @@ class SOHTTPAdapter(HTTPAdapter):
 
 
 # pylint: disable=too-many-ancestors
-class Http(System, Network, MotionDetection, Snapshot,
-           UserManagement, Event, Audio, Record, Video,
-           Log, Ptz, Special, Storage, Nas, Media):
-
-    def __init__(self, host, port, user,
-                 password, verbose=True, protocol='http', ssl_verify=True,
-                 retries_connection=None, timeout_protocol=None):
+class Http(
+    System,
+    Network,
+    MotionDetection,
+    Snapshot,
+    UserManagement,
+    Event,
+    Audio,
+    Record,
+    Video,
+    Log,
+    Ptz,
+    Special,
+    Storage,
+    Nas,
+    Media,
+):
+    def __init__(
+        self,
+        host,
+        port,
+        user,
+        password,
+        verbose=True,
+        protocol="http",
+        ssl_verify=True,
+        retries_connection=None,
+        timeout_protocol=None,
+    ):
 
         self._token_lock = threading.Lock()
         self._cmd_id_lock = threading.Lock()
@@ -96,8 +119,10 @@ class Http(System, Network, MotionDetection, Snapshot,
         self._base_url = self.__base_url()
 
         self._retries_default = (
-            retries_connection if retries_connection is not None
-            else MAX_RETRY_HTTP_CONNECTION)
+            retries_connection
+            if retries_connection is not None
+            else MAX_RETRY_HTTP_CONNECTION
+        )
         self._timeout_default = timeout_protocol or TIMEOUT_HTTP_PROTOCOL
 
         self._token = None
@@ -106,34 +131,41 @@ class Http(System, Network, MotionDetection, Snapshot,
 
     def _generate_token(self):
         """Create authentation to use with requests."""
-        cmd = 'magicBox.cgi?action=getMachineName'
-        _LOGGER.debug('%s Trying Basic Authentication', self)
+        cmd = "magicBox.cgi?action=getMachineName"
+        _LOGGER.debug("%s Trying Basic Authentication", self)
         self._token = requests.auth.HTTPBasicAuth(self._user, self._password)
         try:
             try:
-                resp = self._command(cmd).content.decode('utf-8')
+                resp = self._command(cmd).content.decode("utf-8")
             except LoginError:
-                _LOGGER.debug('%s Trying Digest Authentication', self)
+                _LOGGER.debug("%s Trying Digest Authentication", self)
                 self._token = requests.auth.HTTPDigestAuth(
-                    self._user, self._password)
-                resp = self._command(cmd).content.decode('utf-8')
+                    self._user, self._password
+                )
+                resp = self._command(cmd).content.decode("utf-8")
         except CommError:
             self._token = None
             raise
 
         # check if user passed
         result = resp.lower()
-        if 'invalid' in result or 'error' in result:
-            _LOGGER.debug('%s Result from camera: %s', self,
-                          resp.strip().replace('\r\n', ': '))
+        if "invalid" in result or "error" in result:
+            _LOGGER.debug(
+                "%s Result from camera: %s",
+                self,
+                resp.strip().replace("\r\n", ": "),
+            )
             self._token = None
-            raise LoginError('Invalid credentials')
+            raise LoginError("Invalid credentials")
 
         self._name = pretty(resp.strip())
 
-        _LOGGER.debug('%s Retrieving serial number', self)
-        self._serial = pretty(self._command(
-            'magicBox.cgi?action=getSerialNo').content.decode('utf-8').strip())
+        _LOGGER.debug("%s Retrieving serial number", self)
+        self._serial = pretty(
+            self._command("magicBox.cgi?action=getSerialNo")
+            .content.decode("utf-8")
+            .strip()
+        )
 
     def __repr__(self):
         """Default object representation."""
@@ -142,15 +174,19 @@ class Http(System, Network, MotionDetection, Snapshot,
     def as_dict(self):
         """Callback for __dict__."""
         cdict = self.__dict__.copy()
-        redacted = '**********'
-        cdict['_token'] = redacted
-        cdict['_password'] = redacted
+        redacted = "**********"
+        cdict["_token"] = redacted
+        cdict["_password"] = redacted
         return cdict
 
     # Base methods
     def __base_url(self, param=""):
-        return '%s://%s:%s/cgi-bin/%s' % (self._protocol, self._host,
-                                          str(self._port), param)
+        return "%s://%s:%s/cgi-bin/%s" % (
+            self._protocol,
+            self._host,
+            str(self._port),
+            param,
+        )
 
     def get_base_url(self):
         return self._base_url
@@ -187,7 +223,9 @@ class Http(System, Network, MotionDetection, Snapshot,
                     SOHTTPAdapter(socket_options=_KEEPALIVE_OPTS),
                 )
             for loop in range(1, 2 + retries):
-                _LOGGER.debug("%s Running query %i attempt %s", self, cmd_id, loop)
+                _LOGGER.debug(
+                    "%s Running query %i attempt %s", self, cmd_id, loop
+                )
                 try:
                     resp = session.get(
                         url,
@@ -198,27 +236,39 @@ class Http(System, Network, MotionDetection, Snapshot,
                     )
                     if resp.status_code == 401:
                         _LOGGER.debug(
-                            "%s Query %i: Unauthorized (401)", self, cmd_id)
+                            "%s Query %i: Unauthorized (401)", self, cmd_id
+                        )
                         self._token = None
                         raise LoginError
                     resp.raise_for_status()
                 except requests.RequestException as error:
                     _LOGGER.debug(
-                        "%s Query %i failed due to error: %r", self, cmd_id, error)
+                        "%s Query %i failed due to error: %r",
+                        self,
+                        cmd_id,
+                        error,
+                    )
                     if loop > retries:
                         raise CommError(error)
-                    msg = re.sub(r'at 0x[0-9a-fA-F]+', 'at ADDRESS', repr(error))
-                    _LOGGER.warning("%s Trying again due to error: %s", self, msg)
+                    msg = re.sub(
+                        r"at 0x[0-9a-fA-F]+", "at ADDRESS", repr(error)
+                    )
+                    _LOGGER.warning(
+                        "%s Trying again due to error: %s", self, msg
+                    )
                     continue
                 else:
                     break
 
-        _LOGGER.debug("%s Query %i worked. Exit code: <%s>",
-                      self, cmd_id, resp.status_code)
+        _LOGGER.debug(
+            "%s Query %i worked. Exit code: <%s>",
+            self,
+            cmd_id,
+            resp.status_code,
+        )
         return resp
 
-    def command_audio(self, cmd, file_content, http_header,
-                      timeout=None):
+    def command_audio(self, cmd, file_content, http_header, timeout=None):
         with self._token_lock:
             if not self._token:
                 self._generate_token()
@@ -229,7 +279,7 @@ class Http(System, Network, MotionDetection, Snapshot,
                 files=file_content,
                 auth=self._token,
                 headers=http_header,
-                timeout=timeout or self._timeout_default
+                timeout=timeout or self._timeout_default,
             )
         except requests.exceptions.ReadTimeout:
             pass

--- a/src/amcrest/log.py
+++ b/src/amcrest/log.py
@@ -13,54 +13,52 @@
 
 
 class Log(object):
-
     @property
     def log_clear_all(self):
-        ret = self.command(
-            'log.cgi?action=clear'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("log.cgi?action=clear")
+        return ret.content.decode("utf-8")
 
     def log_show(self, start_time, end_time):
         ret = self.command(
-            'Log.backup?action=All&condition.StartTime='
-            '{0}&condition.EndTime={1}'.format(start_time, end_time)
+            "Log.backup?action=All&condition.StartTime="
+            "{0}&condition.EndTime={1}".format(start_time, end_time)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def log_find_start(self, start_time, end_time):
         ret = self.command(
-            'log.cgi?action=startFind'
-            '&condition.StartTime={0}&condition.EndTime={1}'
-            .format(
-                start_time.strftime('%Y-%m-%d %H:%M:%S'),
-                end_time.strftime('%Y-%m-%d %H:%M:%S')))
+            "log.cgi?action=startFind"
+            "&condition.StartTime={0}&condition.EndTime={1}".format(
+                start_time.strftime("%Y-%m-%d %H:%M:%S"),
+                end_time.strftime("%Y-%m-%d %H:%M:%S"),
+            )
+        )
 
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def log_find_next(self, token, count=100):
-        ret = self.command('log.cgi?action=doFind&token={0}&count={1}'
-                           .format(token, count))
-        return ret.content.decode('utf-8')
+        ret = self.command(
+            "log.cgi?action=doFind&token={0}&count={1}".format(token, count)
+        )
+        return ret.content.decode("utf-8")
 
     def log_find_stop(self, token):
-        ret = self.command('log.cgi?action=stopFind&token={0}'
-                           .format(token))
-        return ret.content.decode('utf-8')
+        ret = self.command("log.cgi?action=stopFind&token={0}".format(token))
+        return ret.content.decode("utf-8")
 
     def log_find(self, start_time, end_time):
-        token = self.log_find_start(start_time, end_time).strip().split('=')[1]
+        token = self.log_find_start(start_time, end_time).strip().split("=")[1]
         to_query = True
 
         while to_query:
             content = self.log_find_next(token)
             tag, count = (
-                list(content.split('\r\n', 1)[0]
-                     .split('=')) + [None])[:2]
+                list(content.split("\r\n", 1)[0].split("=")) + [None]
+            )[:2]
 
             to_query = False
 
-            if (tag == 'found') and (int(count) > 0):
+            if (tag == "found") and (int(count) > 0):
                 to_query = True
 
             yield content

--- a/src/amcrest/media.py
+++ b/src/amcrest/media.py
@@ -14,35 +14,41 @@
 import logging
 
 _LOGGER = logging.getLogger(__name__)
-# fmt: off
 
 
 class Media(object):
-
     def factory_create(self):
-        ret = self.command(
-            'mediaFileFind.cgi?action=factory.create'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("mediaFileFind.cgi?action=factory.create")
+        return ret.content.decode("utf-8")
 
     def factory_close(self, factory_id):
         ret = self.command(
-            'mediaFileFind.cgi?action=factory.close&object={0}'
-            .format(factory_id)
+            "mediaFileFind.cgi?action=factory.close&object={0}".format(
+                factory_id
+            )
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def factory_destroy(self, factory_id):
         ret = self.command(
-            'mediaFileFind.cgi?action=factory.destroy&object={0}'
-            .format(factory_id)
+            "mediaFileFind.cgi?action=factory.destroy&object={0}".format(
+                factory_id
+            )
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def media_file_find_start(self, factory_id,
-                              start_time, end_time, channel=0,
-                              directories=(), types=(), flags=(),
-                              events=(), stream=None):
+    def media_file_find_start(
+        self,
+        factory_id,
+        start_time,
+        end_time,
+        channel=0,
+        directories=(),
+        types=(),
+        flags=(),
+        events=(),
+        stream=None,
+    ):
         """
         https://s3.amazonaws.com/amcrest-files/Amcrest+HTTP+API+3.2017.pdf
 
@@ -71,38 +77,64 @@ class Media(object):
                 If omitted, find files with all the stream types.
         """
 
-        c_dirs = ''.join(['&condition.Dirs[{0}]={1}'.format(k, v)
-                          for k, v in enumerate(directories)])
+        c_dirs = "".join(
+            "&condition.Dirs[{0}]={1}".format(k, v)
+            for k, v in enumerate(directories)
+        )
 
-        c_types = ''.join(['&condition.Types[{0}]={1}'.format(k, v)
-                           for k, v in enumerate(types)])
+        c_types = "".join(
+            "&condition.Types[{0}]={1}".format(k, v)
+            for k, v in enumerate(types)
+        )
 
-        c_flag = ''.join(['&condition.Flag[{0}]={1}'.format(k, v)
-                          for k, v in enumerate(flags)])
+        c_flag = "".join(
+            "&condition.Flag[{0}]={1}".format(k, v)
+            for k, v in enumerate(flags)
+        )
 
-        c_events = ''.join(['&condition.Events[{0}]={1}'.format(k, v)
-                            for k, v in enumerate(events)])
+        c_events = "".join(
+            "&condition.Events[{0}]={1}".format(k, v)
+            for k, v in enumerate(events)
+        )
 
-        c_vs = ('&condition.VideoStream={0}'.format(stream) if stream else '')
+        c_vs = "&condition.VideoStream={0}".format(stream) if stream else ""
 
         ret = self.command(
-            'mediaFileFind.cgi?action=findFile&object={0}&condition.Channel'
-            '={1}&condition.StartTime={2}&condition.EndTime={3}{4}{5}{6}{7}{8}'
-            .format(factory_id, channel, start_time, end_time, c_dirs, c_types,
-                    c_flag, c_events, c_vs)
+            "mediaFileFind.cgi?action=findFile&object={0}&condition.Channel"
+            "={1}&condition.StartTime={2}&condition.EndTime={3}{4}{5}{6}{7}{8}".format(
+                factory_id,
+                channel,
+                start_time,
+                end_time,
+                c_dirs,
+                c_types,
+                c_flag,
+                c_events,
+                c_vs,
+            )
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def media_file_find_next(self, factory_id, count=100):
         ret = self.command(
-            'mediaFileFind.cgi?action=findNextFile&object={0}&count={1}'
-            .format(factory_id, count)
+            "mediaFileFind.cgi?action=findNextFile&object={0}&count={1}".format(
+                factory_id, count
+            )
         )
 
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def find_files(self, start_time, end_time, channel=0,
-                   directories=(), types=(), flags=(), events=(), stream=None):
+    def find_files(
+        self,
+        start_time,
+        end_time,
+        channel=0,
+        directories=(),
+        types=(),
+        flags=(),
+        events=(),
+        stream=None,
+    ):
         """
         https://s3.amazonaws.com/amcrest-files/Amcrest+HTTP+API+3.2017.pdf
 
@@ -128,7 +160,7 @@ class Media(object):
                 The range of stream is {"Main", "Extra1", "Extra2", "Extra3"}.
                 If omitted, find files with all the stream types.
         """
-        factory_id = self.factory_create().strip().split('=')[1]
+        factory_id = self.factory_create().strip().split("=")[1]
         _LOGGER.debug("%s findFile for factory_id=%s", self, factory_id)
 
         search = self.media_file_find_start(
@@ -140,7 +172,8 @@ class Media(object):
             types=types,
             flags=flags,
             events=events,
-            stream=stream)
+            stream=stream,
+        )
 
         if "ok" in search.lower():
             count = 100
@@ -151,11 +184,12 @@ class Media(object):
 
                 # The first line is 'found=N'.
                 # However, it can be 'Error' if e.g. no more files found
-                tag, count = (list(content.split('\r\n', 1)[0]
-                                   .split('=')) + [None])[:2]
+                tag, count = (
+                    list(content.split("\r\n", 1)[0].split("=")) + [None]
+                )[:2]
                 _LOGGER.debug("%s returned %s %s", self, tag, count)
 
-                if tag == 'found':
+                if tag == "found":
                     count = int(count)
                 else:
                     count = None
@@ -176,9 +210,9 @@ class Media(object):
                    reading content into memory
         """
         ret = self.command(
-            'RPC_Loadfile/{0}'.format(file_path),
+            "RPC_Loadfile/{0}".format(file_path),
             timeout_cmd=timeout,
-            stream=stream
+            stream=stream,
         )
         return ret.content
 
@@ -188,9 +222,9 @@ class Media(object):
         '%Y-%m-%d%%20%H:%M:%S'
         """
         ret = self.command(
-            'loadfile.cgi?action=startLoad&channel={0}&startTime={1}'
-            '&endTime={2}&subtype={3}'
-            .format(channel, start_time, end_time, stream)
+            "loadfile.cgi?action=startLoad&channel={0}&startTime={1}"
+            "&endTime={2}&subtype={3}".format(
+                channel, start_time, end_time, stream
+            )
         )
         return ret.content
-# fmt: on

--- a/src/amcrest/motion_detection.py
+++ b/src/amcrest/motion_detection.py
@@ -16,9 +16,9 @@ from amcrest.utils import str2bool
 class MotionDetection(object):
     def __get_config(self, config_name):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name={0}'.format(config_name)
+            "configManager.cgi?action=getConfig&name={0}".format(config_name)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def motion_detection(self):
@@ -26,24 +26,24 @@ class MotionDetection(object):
 
     def is_motion_detector_on(self):
         ret = self.motion_detection
-        status = [s for s in ret.split() if '.Enable=' in s][0]\
-            .split('=')[-1]
+        status = [s for s in ret.split() if ".Enable=" in s][0].split("=")[-1]
         return str2bool(status)  # pylint: disable=no-value-for-parameter
 
     def is_record_on_motion_detection(self):
         ret = self.motion_detection
-        status = [s for s in ret.split() if '.RecordEnable=' in s][0]\
-            .split('=')[-1]
+        status = [s for s in ret.split() if ".RecordEnable=" in s][0].split(
+            "="
+        )[-1]
         return str2bool(status)  # pylint: disable=no-value-for-parameter
 
     @motion_detection.setter
     def motion_detection(self, opt):
         if opt.lower() == "true" or opt.lower() == "false":
             ret = self.command(
-                'configManager.cgi?action='
-                'setConfig&MotionDetect[0].Enable={0}'.format(opt.lower())
+                "configManager.cgi?action="
+                "setConfig&MotionDetect[0].Enable={0}".format(opt.lower())
             )
-            if "ok" in ret.content.decode('utf-8').lower():
+            if "ok" in ret.content.decode("utf-8").lower():
                 return True
 
         return False
@@ -52,11 +52,12 @@ class MotionDetection(object):
     def motion_recording(self, opt):
         if opt.lower() == "true" or opt.lower() == "false":
             ret = self.command(
-                'configManager.cgi?action='
-                'setConfig&MotionDetect[0].EventHandler.RecordEnable={0}'
-                .format(opt.lower())
+                "configManager.cgi?action="
+                "setConfig&MotionDetect[0].EventHandler.RecordEnable={0}".format(
+                    opt.lower()
+                )
             )
-            if "ok" in ret.content.decode('utf-8').lower():
+            if "ok" in ret.content.decode("utf-8").lower():
                 return True
 
         return False

--- a/src/amcrest/nas.py
+++ b/src/amcrest/nas.py
@@ -19,7 +19,5 @@ class Nas(object):
     @property
     def nas_information(self):
         """Return NAS information."""
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=NAS'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=NAS")
+        return ret.content.decode("utf-8")

--- a/src/amcrest/network.py
+++ b/src/amcrest/network.py
@@ -61,7 +61,7 @@ class Network(object):
             28: 16,
             29: 8,
             30: 4,
-            31: 2
+            31: 2,
         }
 
         # If user didn't provide mask, use /24
@@ -110,17 +110,13 @@ class Network(object):
 
     @property
     def wlan_config(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=WLan'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=WLan")
+        return ret.content.decode("utf-8")
 
     @property
     def telnet_config(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=Telnet'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=Telnet")
+        return ret.content.decode("utf-8")
 
     @telnet_config.setter
     def telnet_config(self, status):
@@ -130,38 +126,31 @@ class Network(object):
             true  - Telnet is enabled
         """
         ret = self.command(
-            'configManager.cgi?action=setConfig&Telnet.Enable={0}'.format(
-                status)
+            "configManager.cgi?action=setConfig&Telnet.Enable={0}".format(
+                status
+            )
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def network_config(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=Network'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=Network")
+        return ret.content.decode("utf-8")
 
     @property
     def network_interfaces(self):
-        ret = self.command(
-            'netApp.cgi?action=getInterfaces'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("netApp.cgi?action=getInterfaces")
+        return ret.content.decode("utf-8")
 
     @property
     def upnp_status(self):
-        ret = self.command(
-            'netApp.cgi?action=getUPnPStatus'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("netApp.cgi?action=getUPnPStatus")
+        return ret.content.decode("utf-8")
 
     @property
     def upnp_config(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=UPnP'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=UPnP")
+        return ret.content.decode("utf-8")
 
     @upnp_config.setter
     def upnp_config(self, upnp_opt):
@@ -204,16 +193,14 @@ class Network(object):
         <paramName>=<paramValue>[&<paramName>=<paramValue>...]
         """
         ret = self.command(
-            'configManager.cgi?action=setConfig&{0}'.format(upnp_opt)
+            "configManager.cgi?action=setConfig&{0}".format(upnp_opt)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def ntp_config(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=NTP'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=NTP")
+        return ret.content.decode("utf-8")
 
     @ntp_config.setter
     def ntp_config(self, ntp_opt):
@@ -230,14 +217,12 @@ class Network(object):
         <paramName>=<paramValue>[&<paramName>=<paramValue>...]
         """
         ret = self.command(
-            'configManager.cgi?action=setConfig&{0}'.format(ntp_opt)
+            "configManager.cgi?action=setConfig&{0}".format(ntp_opt)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def rtsp_config(self):
         """Get RTSP configuration."""
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=RTSP'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=RTSP")
+        return ret.content.decode("utf-8")

--- a/src/amcrest/ptz.py
+++ b/src/amcrest/ptz.py
@@ -32,8 +32,11 @@ class Ptz(object):
         return ret.content.decode("utf-8")
 
     @property
-    def ptz_presets_count(self, channel=0):
-        ret = self.ptz_presets_list()
+    def ptz_presets_count(self):
+        return self.get_ptz_presets_count(channel=0)
+
+    def get_ptz_presets_count(self, channel=0):
+        ret = self.ptz_presets_list(channel=channel)
         return ret.count("Name=")
 
     def ptz_status(self, channel=0):

--- a/src/amcrest/ptz.py
+++ b/src/amcrest/ptz.py
@@ -13,26 +13,23 @@
 
 
 class Ptz(object):
-
     @property
     def ptz_config(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=Ptz'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=Ptz")
+        return ret.content.decode("utf-8")
 
     @property
     def ptz_auto_movement(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=PtzAutoMovement'
+            "configManager.cgi?action=getConfig&name=PtzAutoMovement"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def ptz_presets_list(self, channel=0):
         ret = self.command(
-            'ptz.cgi?action=getPresets&channel={0}'.format(channel)
+            "ptz.cgi?action=getPresets&channel={0}".format(channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def ptz_presets_count(self, channel=0):
@@ -41,29 +38,42 @@ class Ptz(object):
 
     def ptz_status(self, channel=0):
         ret = self.command(
-            'ptz.cgi?action=getStatus&channel={0}'.format(channel)
+            "ptz.cgi?action=getStatus&channel={0}".format(channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def ptz_tour_routines_list(self, channel=0):
         ret = self.command(
-            'configManager.cgi?action=getTours&channel={0}'.format(channel)
+            "configManager.cgi?action=getTours&channel={0}".format(channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def ptz_control_command(self, channel=0, action=None, code=None,
-                            arg1=None, arg2=None, arg3=None):
+    def ptz_control_command(
+        self,
+        channel=0,
+        action=None,
+        code=None,
+        arg1=None,
+        arg2=None,
+        arg3=None,
+    ):
 
-        if action is None and code is None and arg1 is None and \
-                arg2 is None and arg3 is None:
+        if (
+            action is None
+            and code is None
+            and arg1 is None
+            and arg2 is None
+            and arg3 is None
+        ):
             raise RuntimeError("code, arg1, arg2, arg3 is required!")
 
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code={2}&arg1={3}'
-            '&arg2={4}&arg3={5}'.format(action, channel, code,
-                                        arg1, arg2, arg3)
+            "ptz.cgi?action={0}&channel={1}&code={2}&arg1={3}"
+            "&arg2={4}&arg3={5}".format(
+                action, channel, code, arg1, arg2, arg3
+            )
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def zoom_in(self, action=None, channel=0):
         """
@@ -76,10 +86,10 @@ class Ptz(object):
         """
 
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=ZoomTele&arg1=0'
-            '&arg2=0&arg3=0'.format(action, channel)
+            "ptz.cgi?action={0}&channel={1}&code=ZoomTele&arg1=0"
+            "&arg2=0&arg3=0".format(action, channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def zoom_out(self, action=None, channel=0):
         """
@@ -91,10 +101,10 @@ class Ptz(object):
         'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.5 sec
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=ZoomWide&arg1=0'
-            '&arg2=0&arg3=0'.format(action, channel)
+            "ptz.cgi?action={0}&channel={1}&code=ZoomWide&arg1=0"
+            "&arg2=0&arg3=0".format(action, channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def move_left(self, action=None, channel=0, vertical_speed=1):
         """
@@ -107,10 +117,10 @@ class Ptz(object):
         'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.5 sec
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=Left&arg1=0'
-            '&arg2={2}&arg3=0'.format(action, channel, vertical_speed)
+            "ptz.cgi?action={0}&channel={1}&code=Left&arg1=0"
+            "&arg2={2}&arg3=0".format(action, channel, vertical_speed)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def move_right(self, action=None, channel=0, vertical_speed=1):
         """
@@ -123,10 +133,10 @@ class Ptz(object):
         'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.5 sec
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=Right&arg1=0'
-            '&arg2={2}&arg3=0'.format(action, channel, vertical_speed)
+            "ptz.cgi?action={0}&channel={1}&code=Right&arg1=0"
+            "&arg2={2}&arg3=0".format(action, channel, vertical_speed)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def move_up(self, action=None, channel=0, vertical_speed=1):
         """
@@ -139,10 +149,10 @@ class Ptz(object):
         'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.2 sec
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=Up&arg1=0'
-            '&arg2={2}&arg3=0'.format(action, channel, vertical_speed)
+            "ptz.cgi?action={0}&channel={1}&code=Up&arg1=0"
+            "&arg2={2}&arg3=0".format(action, channel, vertical_speed)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def move_down(self, action=None, channel=0, vertical_speed=1):
         """
@@ -150,10 +160,10 @@ class Ptz(object):
         'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.2 sec
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=Down&arg1=0'
-            '&arg2={2}&arg3=0'.format(action, channel, vertical_speed)
+            "ptz.cgi?action={0}&channel={1}&code=Down&arg1=0"
+            "&arg2={2}&arg3=0".format(action, channel, vertical_speed)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def focus_near(self, action=None, channel=0):
         """
@@ -162,10 +172,10 @@ class Ptz(object):
             channel             - channel number
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=FocusNear&arg1=0'
-            '&arg2=0&arg3=0'.format(action, channel)
+            "ptz.cgi?action={0}&channel={1}&code=FocusNear&arg1=0"
+            "&arg2=0&arg3=0".format(action, channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def focus_far(self, action=None, channel=0):
         """
@@ -174,10 +184,10 @@ class Ptz(object):
             channel             - channel number
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=FocusFar&arg1=0'
-            '&arg2=0&arg3=0'.format(action, channel)
+            "ptz.cgi?action={0}&channel={1}&code=FocusFar&arg1=0"
+            "&arg2=0&arg3=0".format(action, channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def iris_large(self, action=None, channel=0):
         """
@@ -188,10 +198,10 @@ class Ptz(object):
             channel             - channel number
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=IrisLarge&arg1=0'
-            '&arg2=0&arg3=0'.format(action, channel)
+            "ptz.cgi?action={0}&channel={1}&code=IrisLarge&arg1=0"
+            "&arg2=0&arg3=0".format(action, channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def iris_small(self, action=None, channel=0):
         """
@@ -202,10 +212,10 @@ class Ptz(object):
             channel             - channel number
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=IrisSmall&arg1=0'
-            '&arg2=0&arg3=0'.format(action, channel)
+            "ptz.cgi?action={0}&channel={1}&code=IrisSmall&arg1=0"
+            "&arg2=0&arg3=0".format(action, channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def go_to_preset(self, action=None, channel=0, preset_point_number=1):
         """
@@ -215,12 +225,12 @@ class Ptz(object):
             preset_point_number - preset point number
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=GotoPreset&arg1=0'
-            '&arg2={2}&arg3=0'.format(action, channel, preset_point_number)
+            "ptz.cgi?action={0}&channel={1}&code=GotoPreset&arg1=0"
+            "&arg2={2}&arg3=0".format(action, channel, preset_point_number)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def set_preset(self, action='start', channel=0, preset_point_number=1):
+    def set_preset(self, action="start", channel=0, preset_point_number=1):
         """
         Params:
             action              - start or stop
@@ -228,12 +238,12 @@ class Ptz(object):
             preset_point_number - preset point number
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=SetPreset&arg1=0'
-            '&arg2={2}&arg3=0'.format(action, channel, preset_point_number)
+            "ptz.cgi?action={0}&channel={1}&code=SetPreset&arg1=0"
+            "&arg2={2}&arg3=0".format(action, channel, preset_point_number)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def tour(self, action='start', channel=0, start=True, tour_path_number=1):
+    def tour(self, action="start", channel=0, start=True, tour_path_number=1):
         """
         Params:
             action              - start or stop
@@ -242,15 +252,16 @@ class Ptz(object):
             tour_path_number    - tour path number
         """
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code={2}Tour&arg1={3}'
-            '&arg2=0&arg3=0&arg4=0'.format(
-                action, channel, 'Start' if start else 'Stop',
-                tour_path_number)
+            "ptz.cgi?action={0}&channel={1}&code={2}Tour&arg1={3}"
+            "&arg2=0&arg3=0&arg4=0".format(
+                action, channel, "Start" if start else "Stop", tour_path_number
+            )
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def move_left_up(self, action=None, channel=0,
-                     vertical_speed=1, horizontal_speed=1):
+    def move_left_up(
+        self, action=None, channel=0, vertical_speed=1, horizontal_speed=1
+    ):
         """
         Params:
             action           - start or stop
@@ -260,13 +271,14 @@ class Ptz(object):
         """
 
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=LeftUp&arg1=0'
-            '&arg2={2}&arg3=0'.format(action, channel, vertical_speed)
+            "ptz.cgi?action={0}&channel={1}&code=LeftUp&arg1=0"
+            "&arg2={2}&arg3=0".format(action, channel, vertical_speed)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def move_left_down(self, action=None, channel=0,
-                       vertical_speed=1, horizontal_speed=1):
+    def move_left_down(
+        self, action=None, channel=0, vertical_speed=1, horizontal_speed=1
+    ):
         """
         Params:
             action           - start or stop
@@ -276,13 +288,14 @@ class Ptz(object):
         """
 
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=LeftDown&arg1=0'
-            '&arg2={2}&arg3=0'.format(action, channel, vertical_speed)
+            "ptz.cgi?action={0}&channel={1}&code=LeftDown&arg1=0"
+            "&arg2={2}&arg3=0".format(action, channel, vertical_speed)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def move_right_up(self, action=None, channel=0,
-                      vertical_speed=1, horizontal_speed=1):
+    def move_right_up(
+        self, action=None, channel=0, vertical_speed=1, horizontal_speed=1
+    ):
         """
         Params:
             action           - start or stop
@@ -292,13 +305,14 @@ class Ptz(object):
         """
 
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=RightUp&arg1=0'
-            '&arg2={2}&arg3=0'.format(action, channel, vertical_speed)
+            "ptz.cgi?action={0}&channel={1}&code=RightUp&arg1=0"
+            "&arg2={2}&arg3=0".format(action, channel, vertical_speed)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def move_right_down(self, action=None, channel=0,
-                        vertical_speed=1, horizontal_speed=1):
+    def move_right_down(
+        self, action=None, channel=0, vertical_speed=1, horizontal_speed=1
+    ):
         """
         Params:
             action           - start or stop
@@ -308,14 +322,19 @@ class Ptz(object):
         """
 
         ret = self.command(
-            'ptz.cgi?action={0}&channel={1}&code=RightDown&arg1=0'
-            '&arg2={2}&arg3=0'.format(action, channel, vertical_speed)
+            "ptz.cgi?action={0}&channel={1}&code=RightDown&arg1=0"
+            "&arg2={2}&arg3=0".format(action, channel, vertical_speed)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def move_directly(self,
-                      channel=1, startpoint_x=None, startpoint_y=None,
-                      endpoint_x=None, endpoint_y=None):
+    def move_directly(
+        self,
+        channel=1,
+        startpoint_x=None,
+        startpoint_y=None,
+        endpoint_x=None,
+        endpoint_y=None,
+    ):
         """
 
         Three-dimensional orientation. Move to the rectangle with screen
@@ -327,14 +346,21 @@ class Ptz(object):
             startX, startY, endX and endY - range is 0-8192
         """
 
-        if startpoint_x is None or startpoint_y is None or \
-           endpoint_x is None or endpoint_y is None:
-            raise RuntimeError("Required args, start_point_x, start_point_y"
-                               "end_point_x and end_point_y not speficied")
+        if (
+            startpoint_x is None
+            or startpoint_y is None
+            or endpoint_x is None
+            or endpoint_y is None
+        ):
+            raise RuntimeError(
+                "Required args, start_point_x, start_point_y"
+                "end_point_x and end_point_y not speficied"
+            )
 
         ret = self.command(
-            'ptzBase.cgi?action=moveDirectly&channel={0}&startPoint[0]={1}'
-            '&startPoint[1]={2}&endPoint[0]={3}&endPoint[1]={4}'.format(
-                channel, startpoint_x, startpoint_y, endpoint_x, endpoint_y)
+            "ptzBase.cgi?action=moveDirectly&channel={0}&startPoint[0]={1}"
+            "&startPoint[1]={2}&endPoint[0]={3}&endPoint[1]={4}".format(
+                channel, startpoint_x, startpoint_y, endpoint_x, endpoint_y
+            )
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")

--- a/src/amcrest/record.py
+++ b/src/amcrest/record.py
@@ -13,20 +13,15 @@
 
 
 class Record(object):
-
     @property
     def record_capability(self):
-        ret = self.command(
-            'recordManager.cgi?action=getCaps'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("recordManager.cgi?action=getCaps")
+        return ret.content.decode("utf-8")
 
     @property
     def record_config(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=Record'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=Record")
+        return ret.content.decode("utf-8")
 
     @record_config.setter
     def record_config(self, rec_opt):
@@ -65,31 +60,33 @@ class Record(object):
         """
 
         ret = self.command(
-            'configManager.cgi?action=setConfig&{0}'.format(rec_opt)
+            "configManager.cgi?action=setConfig&{0}".format(rec_opt)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def media_global_config(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=MediaGlobal'
+            "configManager.cgi?action=getConfig&name=MediaGlobal"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def record_mode(self):
-        status_code = {0: 'Automatic',
-                       1: 'Manual',
-                       2: 'Stop',
-                       None: 'Unknown'}
+        status_code = {0: "Automatic", 1: "Manual", 2: "Stop", None: "Unknown"}
 
         try:
             ret = self.command(
-               'configManager.cgi?action=getConfig&name=RecordMode'
+                "configManager.cgi?action=getConfig&name=RecordMode"
             )
 
-            status = int([s for s in ret.content.decode(
-                'utf-8').split() if 'Mode=' in s][0].split('=')[-1])
+            status = int(
+                [
+                    s
+                    for s in ret.content.decode("utf-8").split()
+                    if "Mode=" in s
+                ][0].split("=")[-1]
+            )
 
         # pylint: disable=bare-except
         except:
@@ -119,7 +116,7 @@ class Record(object):
         <paramName>=<paramValue>[&<paramName>=<paramValue>...]
         """
         ret = self.command(
-            'configManager.cgi?action=setConfig&RecordMode'
-            '[{0}].Mode={1}'.format(channel, record_opt)
+            "configManager.cgi?action=setConfig&RecordMode"
+            "[{0}].Mode={1}".format(channel, record_opt)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")

--- a/src/amcrest/snapshot.py
+++ b/src/amcrest/snapshot.py
@@ -22,16 +22,17 @@ _LOGGER = logging.getLogger(__name__)
 class Snapshot(object):
     def __get_config(self, config_name):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name={0}'.format(config_name)
+            "configManager.cgi?action=getConfig&name={0}".format(config_name)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def snapshot_config(self):
-        return self.__get_config('Snap')
+        return self.__get_config("Snap")
 
-    def snapshot(self, channel=None, path_file=None, timeout=None,
-                 stream=True):
+    def snapshot(
+        self, channel=None, path_file=None, timeout=None, stream=True
+    ):
         """
         Args:
 
@@ -55,14 +56,16 @@ class Snapshot(object):
         ret = self.command(cmd, timeout_cmd=timeout, stream=stream)
 
         if path_file:
-            with open(path_file, 'wb') as out_file:
+            with open(path_file, "wb") as out_file:
                 if stream:
                     try:
                         shutil.copyfileobj(ret.raw, out_file)
                     except HTTPError as error:
                         _LOGGER.debug(
                             "%s Snapshot to file failed due to error: %s",
-                            self, repr(error))
+                            self,
+                            repr(error),
+                        )
                         raise CommError(error)
                 else:
                     out_file.write(ret.content)

--- a/src/amcrest/special.py
+++ b/src/amcrest/special.py
@@ -76,16 +76,16 @@ class Special(object):
         )
 
         try:
-            port = (
-                ":"
-                + [
-                    x.split("=")[1]
-                    for x in self.rtsp_config.split()
-                    if x.startswith("table.RTSP.Port=")
-                ][0]
-            )
+            port_num = [
+                x.split("=")[1]
+                for x in self.rtsp_config.split()
+                if x.startswith("table.RTSP.Port=")
+            ][0]
         except IndexError:
             port = ""
+        else:
+            port = ":{}".format(port_num)
+
         return "rtsp://{}:{}@{}{}/{}".format(
             self._user, self._password, self._host, port, cmd
         )

--- a/src/amcrest/special.py
+++ b/src/amcrest/special.py
@@ -20,7 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Special(object):
-
     def realtime_stream(self, channel=1, typeno=0, path_file=None):
         """
         If the stream is redirect to a file, use mplayer tool to
@@ -30,17 +29,23 @@ class Special(object):
         $ mplayer /home/user/Desktop/myvideo
         """
         ret = self.command(
-            'realmonitor.cgi?action=getStream&channel={0}&subtype={1}'.format(
-                channel, typeno), stream=True
+            "realmonitor.cgi?action=getStream&channel={0}&subtype={1}".format(
+                channel, typeno
+            ),
+            stream=True,
         )
 
         if path_file:
             try:
-                with open(path_file, 'wb') as out_file:
+                with open(path_file, "wb") as out_file:
                     shutil.copyfileobj(ret.raw, out_file)
             except HTTPError as error:
-                _LOGGER.debug("%s Realtime stream capture to file failed due "
-                              "to error: %s", self, repr(error))
+                _LOGGER.debug(
+                    "%s Realtime stream capture to file failed due "
+                    "to error: %s",
+                    self,
+                    repr(error),
+                )
                 raise CommError(error)
 
         return ret.raw
@@ -66,16 +71,24 @@ class Special(object):
         if typeno is None:
             typeno = 0
 
-        cmd = 'cam/realmonitor?channel={0}&subtype={1}'.format(
-            channelno, typeno)
+        cmd = "cam/realmonitor?channel={0}&subtype={1}".format(
+            channelno, typeno
+        )
 
         try:
-            port = ':' + [x.split('=')[1] for x in self.rtsp_config.split()
-                          if x.startswith('table.RTSP.Port=')][0]
+            port = (
+                ":"
+                + [
+                    x.split("=")[1]
+                    for x in self.rtsp_config.split()
+                    if x.startswith("table.RTSP.Port=")
+                ][0]
+            )
         except IndexError:
-            port = ''
-        return 'rtsp://{}:{}@{}{}/{}'.format(
-            self._user, self._password, self._host, port, cmd)
+            port = ""
+        return "rtsp://{}:{}@{}{}/{}".format(
+            self._user, self._password, self._host, port, cmd
+        )
 
     # pylint: disable=pointless-string-statement
     """
@@ -123,8 +136,9 @@ class Special(object):
             typeno = 1
 
         cmd = "mjpg/video.cgi?channel={0}&subtype={1}".format(
-            channelno, typeno)
-        return '{0}{1}'.format(self._base_url, cmd)
+            channelno, typeno
+        )
+        return "{0}{1}".format(self._base_url, cmd)
 
     def mjpg_stream(self, channelno=None, typeno=None, path_file=None):
         """
@@ -144,12 +158,14 @@ class Special(object):
 
         if path_file:
             try:
-                with open(path_file, 'wb') as out_file:
+                with open(path_file, "wb") as out_file:
                     shutil.copyfileobj(ret.raw, out_file)
             except HTTPError as error:
                 _LOGGER.debug(
                     "%s MJPEG stream capture to file failed due to error: %s",
-                    self, repr(error))
+                    self,
+                    repr(error),
+                )
                 raise CommError(error)
 
         return ret.raw

--- a/src/amcrest/storage.py
+++ b/src/amcrest/storage.py
@@ -40,12 +40,11 @@ class Storage(object):
         info = self.storage_device_info
         ret = []
         for param in params:
-            try:
-                ret.append(
-                    re.search(".{}=([0-9.]+)".format(param), info).group(1)
-                )
-            except AttributeError:
+            match = re.search(".{}=([0-9.]+)".format(param), info).group(1)
+            if match is None:
                 ret.append(None)
+            else:
+                ret.append(float(match.group(1)))
         if len(params) == 1:
             return ret[0]
         return ret

--- a/src/amcrest/storage.py
+++ b/src/amcrest/storage.py
@@ -14,32 +14,27 @@ import re
 
 from .utils import to_unit, percent
 
-_USED = '.UsedBytes'
-_TOTAL = '.TotalBytes'
+_USED = ".UsedBytes"
+_TOTAL = ".TotalBytes"
 
 
 def _express_as(value, unit):
     try:
         return to_unit(value, unit)
     except (TypeError, ValueError):
-        return 'unknown', unit
+        return "unknown", unit
 
 
 class Storage(object):
-
     @property
     def storage_device_info(self):
-        ret = self.command(
-            'storageDevice.cgi?action=getDeviceAllInfo'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("storageDevice.cgi?action=getDeviceAllInfo")
+        return ret.content.decode("utf-8")
 
     @property
     def storage_device_names(self):
-        ret = self.command(
-            'storageDevice.cgi?action=factory.getCollect'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("storageDevice.cgi?action=factory.getCollect")
+        return ret.content.decode("utf-8")
 
     def _get_storage_values(self, *params):
         info = self.storage_device_info
@@ -47,7 +42,8 @@ class Storage(object):
         for param in params:
             try:
                 ret.append(
-                    re.search('.{}=([0-9.]+)'.format(param), info).group(1))
+                    re.search(".{}=([0-9.]+)".format(param), info).group(1)
+                )
             except AttributeError:
                 ret.append(None)
         if len(params) == 1:
@@ -56,11 +52,11 @@ class Storage(object):
 
     @property
     def storage_used(self):
-        return _express_as(self._get_storage_values(_USED), 'GB')
+        return _express_as(self._get_storage_values(_USED), "GB")
 
     @property
     def storage_total(self):
-        return _express_as(self._get_storage_values(_TOTAL), 'GB')
+        return _express_as(self._get_storage_values(_TOTAL), "GB")
 
     @property
     def storage_used_percent(self):
@@ -68,7 +64,7 @@ class Storage(object):
         try:
             return percent(used, total)
         except (TypeError, ValueError, ZeroDivisionError):
-            return 'unknown'
+            return "unknown"
 
     @property
     def storage_all(self):
@@ -76,8 +72,9 @@ class Storage(object):
         try:
             used_percent = percent(used, total)
         except (TypeError, ValueError, ZeroDivisionError):
-            used_percent = 'unknown'
+            used_percent = "unknown"
         return {
-            'used_percent': used_percent,
-            'used': _express_as(used, 'GB'),
-            'total': _express_as(total, 'GB')}
+            "used_percent": used_percent,
+            "used": _express_as(used, "GB"),
+            "total": _express_as(total, "GB"),
+        }

--- a/src/amcrest/system.py
+++ b/src/amcrest/system.py
@@ -12,6 +12,8 @@
 #
 # vim:sw=4:ts=4:et
 
+from .utils import pretty
+
 
 class System(object):
     """Amcrest system class."""
@@ -66,7 +68,7 @@ class System(object):
             version, build_date = swinfo.split(",")
         else:
             version, build_date = swinfo.split()
-        return (version, build_date)
+        return version, build_date
 
     @property
     def hardware_version(self):
@@ -81,7 +83,7 @@ class System(object):
     @property
     def serial_number(self):
         ret = self.command("magicBox.cgi?action=getSerialNo")
-        return ret.content.decode("utf-8").split("=")[-1]
+        return pretty(ret.content.decode("utf-8"))
 
     @property
     def machine_name(self):

--- a/src/amcrest/system.py
+++ b/src/amcrest/system.py
@@ -15,12 +15,11 @@
 
 class System(object):
     """Amcrest system class."""
+
     @property
     def current_time(self):
-        ret = self.command(
-            'global.cgi?action=getCurrentTime'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("global.cgi?action=getCurrentTime")
+        return ret.content.decode("utf-8")
 
     @current_time.setter
     def current_time(self, date):
@@ -36,106 +35,88 @@ class System(object):
         Return: True
         """
         ret = self.command(
-            'global.cgi?action=setCurrentTime&time={0}'.format(date)
+            "global.cgi?action=setCurrentTime&time={0}".format(date)
         )
 
-        if "ok" in ret.content.decode('utf-8').lower():
+        if "ok" in ret.content.decode("utf-8").lower():
             return True
 
         return False
 
     def __get_config(self, config_name):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name={0}'.format(config_name)
+            "configManager.cgi?action=getConfig&name={0}".format(config_name)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def general_config(self):
-        return self.__get_config('General')
+        return self.__get_config("General")
 
     @property
     def version_http_api(self):
-        ret = self.command(
-            'IntervideoManager.cgi?action=getVersion&Name=CGI'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("IntervideoManager.cgi?action=getVersion&Name=CGI")
+        return ret.content.decode("utf-8")
 
     @property
     def software_information(self):
-        ret = self.command(
-            'magicBox.cgi?action=getSoftwareVersion'
-        )
-        swinfo = ret.content.decode('utf-8')
-        if ',' in swinfo:
-            version, build_date = swinfo.split(',')
+        ret = self.command("magicBox.cgi?action=getSoftwareVersion")
+        swinfo = ret.content.decode("utf-8")
+        if "," in swinfo:
+            version, build_date = swinfo.split(",")
         else:
             version, build_date = swinfo.split()
         return (version, build_date)
 
     @property
     def hardware_version(self):
-        ret = self.command(
-            'magicBox.cgi?action=getHardwareVersion'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("magicBox.cgi?action=getHardwareVersion")
+        return ret.content.decode("utf-8")
 
     @property
     def device_type(self):
-        ret = self.command(
-            'magicBox.cgi?action=getDeviceType'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("magicBox.cgi?action=getDeviceType")
+        return ret.content.decode("utf-8")
 
     @property
     def serial_number(self):
-        ret = self.command(
-            'magicBox.cgi?action=getSerialNo'
-        )
-        return ret.content.decode('utf-8').split('=')[-1]
+        ret = self.command("magicBox.cgi?action=getSerialNo")
+        return ret.content.decode("utf-8").split("=")[-1]
 
     @property
     def machine_name(self):
-        ret = self.command(
-            'magicBox.cgi?action=getMachineName'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("magicBox.cgi?action=getMachineName")
+        return ret.content.decode("utf-8")
 
     @property
     def system_information(self):
-        ret = self.command(
-            'magicBox.cgi?action=getSystemInfo'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("magicBox.cgi?action=getSystemInfo")
+        return ret.content.decode("utf-8")
 
     @property
     def vendor_information(self):
-        ret = self.command(
-            'magicBox.cgi?action=getVendor'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("magicBox.cgi?action=getVendor")
+        return ret.content.decode("utf-8")
 
     @property
     def onvif_information(self):
         ret = self.command(
-            'IntervideoManager.cgi?action=getVersion&Name=Onvif'
+            "IntervideoManager.cgi?action=getVersion&Name=Onvif"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def config_backup(self, filename=None):
-        ret = self.command(
-            'Config.backup?action=All'
-        )
+        ret = self.command("Config.backup?action=All")
 
         if not ret:
             return None
 
         if filename:
             with open(filename, "w+") as cfg:
-                cfg.write(ret.content.decode('utf-8'))
+                cfg.write(ret.content.decode("utf-8"))
             return None
 
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def device_class(self):
@@ -143,25 +124,21 @@ class System(object):
         During the development, device IP2M-841B didn't
         responde for this call, adding it anyway.
         """
-        ret = self.command(
-            'magicBox.cgi?action=getDeviceClass'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("magicBox.cgi?action=getDeviceClass")
+        return ret.content.decode("utf-8")
 
     def shutdown(self):
         """
         From the testings, shutdown acts like "reboot now"
         """
-        ret = self.command(
-            'magicBox.cgi?action=shutdown'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("magicBox.cgi?action=shutdown")
+        return ret.content.decode("utf-8")
 
     def reboot(self, delay=None):
-        cmd = 'magicBox.cgi?action=reboot'
+        cmd = "magicBox.cgi?action=reboot"
 
         if delay:
             cmd += "&delay={0}".format(delay)
 
         ret = self.command(cmd)
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")

--- a/src/amcrest/user_management.py
+++ b/src/amcrest/user_management.py
@@ -13,48 +13,48 @@
 
 
 class UserManagement(object):
-
     def info_user(self, username):
         ret = self.command(
-            'userManager.cgi?action=getUserInfo&name={0}'.format(username)
+            "userManager.cgi?action=getUserInfo&name={0}".format(username)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def info_all_users(self):
-        ret = self.command(
-            'userManager.cgi?action=getUserInfoAll'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("userManager.cgi?action=getUserInfoAll")
+        return ret.content.decode("utf-8")
 
     @property
     def info_all_active_users(self):
-        ret = self.command(
-            'userManager.cgi?action=getActiveUserInfoAll'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("userManager.cgi?action=getActiveUserInfoAll")
+        return ret.content.decode("utf-8")
 
     def info_group(self, group):
         ret = self.command(
-            'userManager.cgi?action=getGroupInfo&name={0}'.format(group)
+            "userManager.cgi?action=getGroupInfo&name={0}".format(group)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def info_all_groups(self):
-        ret = self.command(
-            'userManager.cgi?action=getGroupInfoAll'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("userManager.cgi?action=getGroupInfoAll")
+        return ret.content.decode("utf-8")
 
     def delete_user(self, username):
         ret = self.command(
-            'userManager.cgi?action=deleteUser&name={0}'.format(username)
+            "userManager.cgi?action=deleteUser&name={0}".format(username)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def add_user(self, username, password, group, sharable=True,
-                 reserved=False, memo=None):
+    def add_user(
+        self,
+        username,
+        password,
+        group,
+        sharable=True,
+        reserved=False,
+        memo=None,
+    ):
         """
         Params:
             username - username for user
@@ -69,17 +69,23 @@ class UserManagement(object):
             memo - memo to user
         """
 
-        cmd = "userManager.cgi?action=addUser&user.Name={0}" \
-              "&user.Password={1}&user.Group={2}&user.Sharable={3}" \
-              "&user.Reserved={4}".format(
-                  username, password, group.lower(), sharable.lower(),
-                  reserved.lower())
+        cmd = (
+            "userManager.cgi?action=addUser&user.Name={0}"
+            "&user.Password={1}&user.Group={2}&user.Sharable={3}"
+            "&user.Reserved={4}".format(
+                username,
+                password,
+                group.lower(),
+                sharable.lower(),
+                reserved.lower(),
+            )
+        )
 
         if memo:
             cmd += "&user.Memo=%s" % memo
 
         ret = self.command(cmd)
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def modify_password(self, username, newpwd, oldpwd):
         """
@@ -89,10 +95,10 @@ class UserManagement(object):
             oldpwd - old password
         """
         ret = self.command(
-            'userManager.cgi?action=modifyPassword&name={0}&pwd={1}'
-            '&pwdOld={2}'.format(username, newpwd, oldpwd)
+            "userManager.cgi?action=modifyPassword&name={0}&pwd={1}"
+            "&pwdOld={2}".format(username, newpwd, oldpwd)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def modify_user(self, username, attribute, value):
         """
@@ -104,8 +110,7 @@ class UserManagement(object):
             value - the new value for attribute
         """
 
-        cmd = "userManager.cgi?action=modifyUser&name={0}".format(
-            username)
+        cmd = "userManager.cgi?action=modifyUser&name={0}".format(username)
 
         if attribute.lower() == "group":
             cmd += "&user.Group=%s" % value.lower()
@@ -120,4 +125,4 @@ class UserManagement(object):
             cmd += "&user.Memo=%s" % value.lower()
 
         ret = self.command(cmd)
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")

--- a/src/amcrest/utils.py
+++ b/src/amcrest/utils.py
@@ -77,15 +77,19 @@ def extract_audio_video_enabled(param, resp):
     ]
 
 
-def enable_audio_video_cmd(param, enable):
+def enable_audio_video_cmd(param, enable, channel):
     """Return command to enable/disable all audio/video streams."""
-    cmd = "configManager.cgi?action=setConfig"
     formats = [("Extra", 3), ("Main", 4)]
     if param == "Video":
         formats.append(("Snap", 3))
-    for fmt, num in formats:
-        for i in range(num):
-            cmd += "&Encode[0].{}Format[{}].{}Enable={}".format(
-                fmt, i, param, str(enable).lower()
-            )
-    return cmd
+
+    set_enable = str(enable).lower()
+    cmds = ["configManager.cgi?action=setConfig"]
+    cmds.extend(
+        "Encode[{}].{}Format[{}].{}Enable={}".format(
+            channel, fmt, i, param, set_enable
+        )
+        for fmt, num in formats
+        for i in range(num)
+    )
+    return "&".join(cmds)

--- a/src/amcrest/utils.py
+++ b/src/amcrest/utils.py
@@ -20,12 +20,12 @@ PRECISION = 2
 
 
 def clean_url(url):
-    host = re.sub(r'^http[s]?://', '', url, flags=re.IGNORECASE)
-    host = re.sub(r'/$', '', host)
+    host = re.sub(r"^http[s]?://", "", url, flags=re.IGNORECASE)
+    host = re.sub(r"/$", "", host)
     return host
 
 
-def pretty(value, delimiter='='):
+def pretty(value, delimiter="="):
     """Format string key=value."""
     try:
         return value.split(delimiter)[1]
@@ -54,15 +54,15 @@ def str2bool(value):
     return bool(value)
 
 
-def to_unit(value, unit='B'):
+def to_unit(value, unit="B"):
     """Convert bytes to give unit."""
-    byte_array = ['B', 'KB', 'MB', 'GB', 'TB']
+    byte_array = ["B", "KB", "MB", "GB", "TB"]
 
     if not isinstance(value, (int, float)):
         value = float(value)
 
     if unit in byte_array:
-        result = value / 1024**byte_array.index(unit)
+        result = value / 1024 ** byte_array.index(unit)
         return round(result, PRECISION), unit
 
     return value
@@ -70,18 +70,22 @@ def to_unit(value, unit='B'):
 
 def extract_audio_video_enabled(param, resp):
     """Extract if any audio/video stream enabled from response."""
-    return 'true' in [part.split('=')[1] for part in resp.split()
-                      if '.{}Enable='.format(param) in part]
+    return "true" in [
+        part.split("=")[1]
+        for part in resp.split()
+        if ".{}Enable=".format(param) in part
+    ]
 
 
 def enable_audio_video_cmd(param, enable):
     """Return command to enable/disable all audio/video streams."""
-    cmd = 'configManager.cgi?action=setConfig'
-    formats = [('Extra', 3), ('Main', 4)]
-    if param == 'Video':
-        formats.append(('Snap', 3))
+    cmd = "configManager.cgi?action=setConfig"
+    formats = [("Extra", 3), ("Main", 4)]
+    if param == "Video":
+        formats.append(("Snap", 3))
     for fmt, num in formats:
         for i in range(num):
-            cmd += '&Encode[0].{}Format[{}].{}Enable={}'.format(
-                fmt, i, param, str(enable).lower())
+            cmd += "&Encode[0].{}Format[{}].{}Enable={}".format(
+                fmt, i, param, str(enable).lower()
+            )
     return cmd

--- a/src/amcrest/video.py
+++ b/src/amcrest/video.py
@@ -132,24 +132,62 @@ class Video(object):
             field = param
         else:
             field = "{}Options.{}".format(profile, param)
-        return utils.pretty(
-            [
-                opt
-                for opt in self.video_in_options.split()
-                if "].{}=".format(field) in opt
-            ][0]
-        )
+        return [
+            utils.pretty(opt)
+            for opt in self.video_in_options.split()
+            if "].{}=".format(field) in opt
+        ]
 
-    def set_video_in_option(self, param, value, profile="Day"):
+    def set_video_in_option(self, param, value, profile="Day", channel=0):
         if profile == "Day":
             field = param
         else:
             field = "{}Options.{}".format(profile, param)
         ret = self.command(
             "configManager.cgi?action=setConfig"
-            "&VideoInOptions[0].{}={}".format(field, value)
+            "&VideoInOptions[{}].{}={}".format(channel, field, value)
         )
         return ret.content.decode("utf-8")
+
+    def get_day_night_color(self, channel):
+        """
+        Return Day & Night Color Mode for Day profile.
+
+        Result is 0: always multicolor
+                  1: autoswitch along with brightness
+                  2: always monochrome
+        """
+        values = [int(x) for x in self.video_in_option("DayNightColor")]
+        return values[channel]
+
+    def set_day_night_color(self, value, channel):
+        return self.set_video_in_option(
+            "DayNightColor", value, channel=channel
+        )
+
+    def is_smart_ir_on(self, channel):
+        """Return if SmartIR is on."""
+        return self.video_in_option("InfraRed")[channel] == "false"
+
+    def set_smart_ir(self, value, channel):
+        # It's not clear why from the HTTP API SDK doc, but setting InfraRed
+        # to false sets the Night Vision Mode to SmartIR, whereas setting it
+        # to true sets the Night Vision Mode to OFF. Night Vision Mode has a
+        # third setting of Manual, but that must be selected some other way
+        # via the HTTP API.
+        value = "false" if value else "true"
+        return self.set_video_in_option("InfraRed", value, channel=channel)
+
+    def is_video_enabled(self, channel):
+        """Return if any video stream enabled."""
+        is_enabled = utils.extract_audio_video_enabled(
+            "Video", self.encode_media
+        )
+        return is_enabled[channel]
+
+    def set_video_enabled(self, enable, channel):
+        self.command(utils.enable_audio_video_cmd("Video", enable, channel))
+        self.set_smart_ir(enable, channel)
 
     @property
     def day_night_color(self):
@@ -160,37 +198,31 @@ class Video(object):
                   1: autoswitch along with brightness
                   2: always monochrome
         """
-        return int(self.video_in_option("DayNightColor"))
+        return self.get_day_night_color(channel=0)
 
     @day_night_color.setter
     def day_night_color(self, value):
-        return self.set_video_in_option("DayNightColor", value)
+        return self.set_video_in_option("DayNightColor", value, channel=0)
 
     @property
     def smart_ir(self):
         """Return if SmartIR is on."""
-        return self.video_in_option("InfraRed") == "false"
+        return self.is_smart_ir_on(channel=0)
 
     @smart_ir.setter
     def smart_ir(self, value):
-        # It's not clear why from the HTTP API SDK doc, but setting InfraRed
-        # to false sets the Night Vision Mode to SmartIR, whereas setting it
-        # to true sets the Night Vision Mode to OFF. Night Vision Mode has a
-        # third setting of Manual, but that must be selected some other way
-        # via the HTTP API.
-        return self.set_video_in_option("InfraRed", str(not value).lower())
+        return self.set_smart_ir(value, channel=0)
+
+    @property
+    def video_enabled(self):
+        """Return if any video stream enabled."""
+        return self.is_video_enabled(channel=0)
+
+    @video_enabled.setter
+    def video_enabled(self, enable):
+        self.set_video_enabled(enable, channel=0)
 
     @property
     def video_out_options(self):
         ret = self.command("configManager.cgi?action=getConfig&name=VideoOut")
         return ret.content.decode("utf-8")
-
-    @property
-    def video_enabled(self):
-        """Return if any video stream enabled."""
-        return utils.extract_audio_video_enabled("Video", self.encode_media)
-
-    @video_enabled.setter
-    def video_enabled(self, enable):
-        self.command(utils.enable_audio_video_cmd("Video", enable))
-        self.smart_ir = enable

--- a/src/amcrest/video.py
+++ b/src/amcrest/video.py
@@ -14,122 +14,113 @@ from . import utils
 
 
 class Video(object):
-
     @property
     def video_max_extra_stream(self):
         ret = self.command(
-            'magicBox.cgi?action=getProductDefinition&name=MaxExtraStream'
+            "magicBox.cgi?action=getProductDefinition&name=MaxExtraStream"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def video_color_config(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=VideoColor'
+            "configManager.cgi?action=getConfig&name=VideoColor"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def encode_capability(self):
-        ret = self.command(
-            'encode.cgi?action=getCaps'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("encode.cgi?action=getCaps")
+        return ret.content.decode("utf-8")
 
     def encode_config_capability(self, channel):
         ret = self.command(
-            'encode.cgi?action=getConfigCaps&channel={0}'.format(channel)
+            "encode.cgi?action=getConfigCaps&channel={0}".format(channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def encode_media(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=Encode'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=Encode")
+        return ret.content.decode("utf-8")
 
     @property
     def encode_region_interested(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=VideoEncodeROI'
+            "configManager.cgi?action=getConfig&name=VideoEncodeROI"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def video_channel_title(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=ChannelTitle'
+            "configManager.cgi?action=getConfig&name=ChannelTitle"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     # pylint: disable=invalid-name
     @property
     def video_input_channels_device_supported(self):
-        ret = self.command(
-            'devVideoInput.cgi?action=getCollect'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("devVideoInput.cgi?action=getCollect")
+        return ret.content.decode("utf-8")
 
     # pylint: disable=invalid-name
     @property
     def video_output_channels_device_supported(self):
-        ret = self.command(
-            'devVideoOutput.cgi?action=getCollect'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("devVideoOutput.cgi?action=getCollect")
+        return ret.content.decode("utf-8")
 
     # pylint: disable=invalid-name
     @property
     def video_max_remote_input_channels(self):
         ret = self.command(
-            'magicBox.cgi?action=getProductDefinition&name='
-            'MaxRemoteInputChannels'
+            "magicBox.cgi?action=getProductDefinition&name="
+            "MaxRemoteInputChannels"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def video_standard(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=VideoStandard'
+            "configManager.cgi?action=getConfig&name=VideoStandard"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @video_standard.setter
     def video_standard(self, std):
         ret = self.command(
-            'configManager.cgi?action=setConfig&VideoStandard={0}'.format(std)
+            "configManager.cgi?action=setConfig&VideoStandard={0}".format(std)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def video_widget_config(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=VideoWidget'
+            "configManager.cgi?action=getConfig&name=VideoWidget"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def video_input_capability(self, channel):
         ret = self.command(
-            'devVideoInput.cgi?action=getCaps&channel={0}'.format(channel)
+            "devVideoInput.cgi?action=getCaps&channel={0}".format(channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     def video_coordinates_current_window(self, channel):
         ret = self.command(
-            'devVideoInput.cgi?action='
-            'getCurrentWindow&channel={0}'.format(channel)
+            "devVideoInput.cgi?action="
+            "getCurrentWindow&channel={0}".format(channel)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def video_in_options(self):
         ret = self.command(
-            'configManager.cgi?action=getConfig&name=VideoInOptions'
+            "configManager.cgi?action=getConfig&name=VideoInOptions"
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
-    def video_in_option(self, param, profile='Day'):
+    def video_in_option(self, param, profile="Day"):
         """
         Return video input option.
 
@@ -137,24 +128,28 @@ class Video(object):
             param - parameter, such as 'DayNightColor'
             profile - 'Day', 'Night' or 'Normal'
         """
-        if profile == 'Day':
+        if profile == "Day":
             field = param
         else:
-            field = '{}Options.{}'.format(profile, param)
+            field = "{}Options.{}".format(profile, param)
         return utils.pretty(
-            [opt for opt in self.video_in_options.split()
-             if '].{}='.format(field) in opt][0])
+            [
+                opt
+                for opt in self.video_in_options.split()
+                if "].{}=".format(field) in opt
+            ][0]
+        )
 
-    def set_video_in_option(self, param, value, profile='Day'):
-        if profile == 'Day':
+    def set_video_in_option(self, param, value, profile="Day"):
+        if profile == "Day":
             field = param
         else:
-            field = '{}Options.{}'.format(profile, param)
+            field = "{}Options.{}".format(profile, param)
         ret = self.command(
-            'configManager.cgi?action=setConfig'
-            '&VideoInOptions[0].{}={}'.format(field, value)
+            "configManager.cgi?action=setConfig"
+            "&VideoInOptions[0].{}={}".format(field, value)
         )
-        return ret.content.decode('utf-8')
+        return ret.content.decode("utf-8")
 
     @property
     def day_night_color(self):
@@ -165,16 +160,16 @@ class Video(object):
                   1: autoswitch along with brightness
                   2: always monochrome
         """
-        return int(self.video_in_option('DayNightColor'))
+        return int(self.video_in_option("DayNightColor"))
 
     @day_night_color.setter
     def day_night_color(self, value):
-        return self.set_video_in_option('DayNightColor', value)
+        return self.set_video_in_option("DayNightColor", value)
 
     @property
     def smart_ir(self):
         """Return if SmartIR is on."""
-        return self.video_in_option('InfraRed') == 'false'
+        return self.video_in_option("InfraRed") == "false"
 
     @smart_ir.setter
     def smart_ir(self, value):
@@ -183,21 +178,19 @@ class Video(object):
         # to true sets the Night Vision Mode to OFF. Night Vision Mode has a
         # third setting of Manual, but that must be selected some other way
         # via the HTTP API.
-        return self.set_video_in_option('InfraRed', str(not value).lower())
+        return self.set_video_in_option("InfraRed", str(not value).lower())
 
     @property
     def video_out_options(self):
-        ret = self.command(
-            'configManager.cgi?action=getConfig&name=VideoOut'
-        )
-        return ret.content.decode('utf-8')
+        ret = self.command("configManager.cgi?action=getConfig&name=VideoOut")
+        return ret.content.decode("utf-8")
 
     @property
     def video_enabled(self):
         """Return if any video stream enabled."""
-        return utils.extract_audio_video_enabled('Video', self.encode_media)
+        return utils.extract_audio_video_enabled("Video", self.encode_media)
 
     @video_enabled.setter
     def video_enabled(self, enable):
-        self.command(utils.enable_audio_video_cmd('Video', enable))
+        self.command(utils.enable_audio_video_cmd("Video", enable))
         self.smart_ir = enable

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py27, py35, py36, py37, py38, py39
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Add additional methods to be able to use specified channels, allowing
this to be used with NVRs.  Currently, the `@property`'s read from
channel 0, change these methods to call into the new functions for the
channel it used previously, so these should not change behavior.

Behavioral changes include:
- Event.event_channels_happened returns a list of channels where the
  event has occurred, rather than the request output.  This simplifies
  the `is_x_detected` methods.
- The `Event.is_x_detected` methods return a list of channels where the
  event occurred, rathen than a bool of if the event occurred or not.
- `Video.video_in_option` returns a list of all option configurations
  for all channels, rather than just returning the first option.  All of
  the properties (eg `video_enabled` and `day_night_color`) are
  unchanged, as they check channel 0.
- Some of the `System` properties (eg `serial_number`) are split with
  `pretty()` to give just the value rather than the full message
  payload.