### PR TITLE
Bump version 1.8.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,8 +9,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 define([VERSION_MAJOR], [1])
-define([VERSION_MINOR], [7])
-define([VERSION_FIX], [2])
+define([VERSION_MINOR], [8])
+define([VERSION_FIX], [0])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
 define([VERSION_SUFFIX], [_master])
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 
 setup(name='amcrest',
-      version='1.7.2',
+      version='1.8.0',
       description='Python wrapper implementation for Amcrest cameras.',
       long_description=readme(),
       author='Douglas Schilling Landgraf, Marcelo Moreira de Mello',


### PR DESCRIPTION
Breaking changes
* Python 2 no longer supported, Python 3.6 is the minimum required
  version
* PTZ commands (e.g. `zoom_in`, `move_left`) require boolean value for
  `start` parameter, rather than `"start"` and `"stop"` strings for the
  `action` parameter

New features
* Smart motion detection events added as `is_human_detected` and
  `is_vehicle_detected` properties.
* Added methods to query separate channels to allow using multiple
  cameras on NVRs.
* New `position_abs` PTZ function to allow for absolute angular
  positioning.
* New function to override ONVIF login checking for admin-only.
* Type annotations added to allow for type checking.

Closes #180 