### PR TITLE
Add async APIs throughout

### DIFF
--- a/cli/amcrest-cli
+++ b/cli/amcrest-cli
@@ -625,7 +625,7 @@ def main():
             camera.go_to_preset(channel=channel, preset_point_number=preset_point_number)
 
         elif args.log_clear_all:
-            print(camera.log_clear_all)
+            print(camera.log_clear_all())
 
         elif args.video_standard == -1:
             print(camera.video_standard)

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,15 @@ norecursedirs = .git
 max-line-length = 79
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
+disallow_subclassing_any = True
 no_implicit_optional = True
+show_error_codes = True
+strict_equality = True
+warn_incomplete_stub = True
+warn_redundant_casts = True
+warn_unreachable = True
 warn_unused_configs = True
 warn_unused_ignores = True
-warn_unreachable = True
 [mypy-urllib3.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -3,33 +3,39 @@ from setuptools import setup, find_packages
 
 
 def readme():
-    with open('README.rst') as desc:
+    with open("README.rst") as desc:
         return desc.read()
 
 
-setup(name='amcrest',
-      version='1.8.1',
-      description='Python wrapper implementation for Amcrest cameras.',
-      long_description=readme(),
-      author='Douglas Schilling Landgraf, Marcelo Moreira de Mello',
-      author_email='dougsland@gmail.com, tchello.mello@gmail.com',
-      url='http://github.com/tchellomello/python-amcrest',
-      license='GPLv2',
-      install_requires=[
-          'argcomplete', 'requests', 'typing_extensions', 'urllib3'
-      ],
-      package_dir={'': 'src'},
-      packages=find_packages('src'),
-      include_package_data=True,
-      package_data={"amcrest": ["py.typed"]},
-      test_suite='tests',
-      scripts=['cli/amcrest-cli', 'tui/amcrest-tui'],
-      zip_safe=True,
-      keywords="amcrest camera python",
-      classifiers=[
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-      ])
+setup(
+    name="amcrest",
+    version="1.8.1",
+    description="Python wrapper implementation for Amcrest cameras.",
+    long_description=readme(),
+    author="Douglas Schilling Landgraf, Marcelo Moreira de Mello",
+    author_email="dougsland@gmail.com, tchello.mello@gmail.com",
+    url="http://github.com/tchellomello/python-amcrest",
+    license="GPLv2",
+    install_requires=[
+        "argcomplete",
+        "httpx",
+        "requests",
+        "typing_extensions",
+        "urllib3",
+    ],
+    package_dir={"": "src"},
+    packages=find_packages("src"),
+    include_package_data=True,
+    package_data={"amcrest": ["py.typed"]},
+    test_suite="tests",
+    scripts=["cli/amcrest-cli", "tui/amcrest-tui"],
+    zip_safe=True,
+    keywords="amcrest camera python",
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
+)

--- a/src/amcrest/audio.py
+++ b/src/amcrest/audio.py
@@ -27,8 +27,18 @@ class Audio(Http):
         return ret.content.decode()
 
     @property
+    async def async_audio_input_channels_numbers(self) -> str:
+        ret = await self.async_command("devAudioInput.cgi?action=getCollect")
+        return ret.content.decode()
+
+    @property
     def audio_output_channels_numbers(self) -> str:
         ret = self.command("devAudioOutput.cgi?action=getCollect")
+        return ret.content.decode()
+
+    @property
+    async def async_audio_output_channels_numbers(self) -> str:
+        ret = await self.async_command("devAudioOutput.cgi?action=getCollect")
         return ret.content.decode()
 
     def play_wav(
@@ -141,6 +151,21 @@ class Audio(Http):
 
         return ret.raw
 
+    @property
+    def audio_enabled(self) -> bool:
+        """Return if any audio stream enabled."""
+        return self.is_audio_enabled()
+
+    @audio_enabled.setter
+    def audio_enabled(self, enable: bool) -> None:
+        """Enable/disable all audio streams."""
+        self.set_audio_enabled(enable)
+
+    @property
+    async def async_audio_enabled(self) -> bool:
+        """Return if any audio stream enabled."""
+        return await self.async_is_audio_enabled()
+
     def is_audio_enabled(
         self, *, channel: int = 0, stream: str = "Main", stream_type: int = 0
     ) -> bool:
@@ -160,16 +185,24 @@ class Audio(Http):
         )
         return is_enabled[channel]
 
+    async def async_is_audio_enabled(
+        self, *, channel: int = 0, stream: str = "Main", stream_type: int = 0
+    ) -> bool:
+        """Return if any audio stream enabled on the given channel."""
+        is_enabled = utils.extract_audio_video_enabled(
+            f"{stream}Format[{stream_type}].Audio",
+            await self.async_encode_media,  # type: ignore[attr-defined]
+        )
+        return is_enabled[channel]
+
     def set_audio_enabled(self, enable: bool, *, channel: int = 0) -> None:
         """Enable/disable all audio streams on given channel."""
         self.command(utils.enable_audio_video_cmd("Audio", enable, channel))
 
-    @property
-    def audio_enabled(self) -> bool:
-        """Return if any audio stream enabled."""
-        return self.is_audio_enabled()
-
-    @audio_enabled.setter
-    def audio_enabled(self, enable: bool) -> None:
-        """Enable/disable all audio streams."""
-        self.set_audio_enabled(enable)
+    async def async_set_audio_enabled(
+        self, enable: bool, *, channel: int = 0
+    ) -> None:
+        """Enable/disable all audio streams on given channel."""
+        await self.async_command(
+            utils.enable_audio_video_cmd("Audio", enable, channel)
+        )

--- a/src/amcrest/event.py
+++ b/src/amcrest/event.py
@@ -10,9 +10,19 @@
 # vim:sw=4:ts=4:et
 import logging
 import re
-from typing import Iterable, List, Optional, Tuple
+from typing import (
+    Any,
+    AsyncIterator,
+    AsyncIterable,
+    Dict,
+    Iterator,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+)
 
-from requests import RequestException, Response
+from requests import RequestException
 from urllib3.exceptions import HTTPError
 
 from .exceptions import CommError
@@ -26,9 +36,18 @@ _REG_PARSE_MALFORMED_JSON = re.compile(
 )
 
 
-def _event_lines(ret: Response) -> Iterable[str]:
+def _event_lines(ret: Iterable[str]) -> Iterator[str]:
     line = []
-    for char in ret.iter_content(decode_unicode=True):
+    for char in ret:
+        line.append(char)
+        if line[-2:] == ["\r", "\n"]:
+            yield "".join(line).strip()
+            line.clear()
+
+
+async def _async_event_lines(ret: AsyncIterable[str]) -> AsyncIterator[str]:
+    line = []
+    async for char in ret:
         line.append(char)
         if line[-2:] == ["\r", "\n"]:
             yield "".join(line).strip()
@@ -37,9 +56,17 @@ def _event_lines(ret: Response) -> Iterable[str]:
 
 class Event(Http):
     def event_handler_config(self, handlername: str) -> str:
-        ret = self.command(
-            f"configManager.cgi?action=getConfig&name={handlername}"
-        )
+        return self._get_config(handlername)
+
+    async def async_event_handler_config(self, handlername: str) -> str:
+        return await self._async_get_config(handlername)
+
+    def alarm_handler(self, alarm_name: str) -> str:
+        ret = self.command("alarm.cgi?action={alarm_name}")
+        return ret.content.decode()
+
+    async def async_alarm_handler(self, alarm_name: str) -> str:
+        ret = await self.async_command("alarm.cgi?action={alarm_name}")
         return ret.content.decode()
 
     @property
@@ -47,60 +74,112 @@ class Event(Http):
         return self.event_handler_config("Alarm")
 
     @property
+    async def async_alarm_config(self) -> str:
+        return await self.async_event_handler_config("Alarm")
+
+    @property
     def alarm_out_config(self) -> str:
         return self.event_handler_config("AlarmOut")
 
     @property
+    async def async_alarm_out_config(self) -> str:
+        return await self.async_event_handler_config("AlarmOut")
+
+    @property
     def alarm_input_channels(self) -> str:
-        ret = self.command("alarm.cgi?action=getInSlots")
-        return ret.content.decode()
+        return self.alarm_handler("getInSlots")
+
+    @property
+    async def async_alarm_input_channels(self) -> str:
+        return await self.async_alarm_handler("getInSlots")
 
     @property
     def alarm_output_channels(self) -> str:
-        ret = self.command("alarm.cgi?action=getOutSlots")
-        return ret.content.decode()
+        return self.alarm_handler("getOutSlots")
+
+    @property
+    async def async_alarm_output_channels(self) -> str:
+        return await self.async_alarm_handler("getOutSlots")
 
     @property
     def alarm_states_input_channels(self) -> str:
-        ret = self.command("alarm.cgi?action=getInState")
-        return ret.content.decode()
+        return self.alarm_handler("getInState")
+
+    @property
+    async def async_alarm_states_input_channels(self) -> str:
+        return await self.async_alarm_handler("getInState")
 
     @property
     def alarm_states_output_channels(self) -> str:
-        ret = self.command("alarm.cgi?action=getOutState")
-        return ret.content.decode()
+        return self.alarm_handler("getOutState")
+
+    @property
+    async def async_alarm_states_output_channels(self) -> str:
+        return await self.async_alarm_handler("getOutState")
 
     @property
     def video_blind_detect_config(self) -> str:
         return self.event_handler_config("BlindDetect")
 
     @property
+    async def async_video_blind_detect_config(self) -> str:
+        return await self.async_event_handler_config("BlindDetect")
+
+    @property
     def video_loss_detect_config(self) -> str:
         return self.event_handler_config("LossDetect")
+
+    @property
+    async def async_video_loss_detect_config(self) -> str:
+        return await self.async_event_handler_config("LossDetect")
 
     @property
     def event_login_failure(self) -> str:
         return self.event_handler_config("LoginFailureAlarm")
 
     @property
+    async def async_event_login_failure(self) -> str:
+        return await self.async_event_handler_config("LoginFailureAlarm")
+
+    @property
     def event_storage_not_exist(self) -> str:
         return self.event_handler_config("StorageNotExist")
+
+    @property
+    async def async_event_storage_not_exist(self) -> str:
+        return await self.async_event_handler_config("StorageNotExist")
 
     @property
     def event_storage_access_failure(self) -> str:
         return self.event_handler_config("StorageFailure")
 
     @property
+    async def async_event_storage_access_failure(self) -> str:
+        return await self.async_event_handler_config("StorageFailure")
+
+    @property
     def event_storage_low_space(self) -> str:
         return self.event_handler_config("StorageLowSpace")
+
+    @property
+    async def async_event_storage_low_space(self) -> str:
+        return await self.async_event_handler_config("StorageLowSpace")
 
     @property
     def event_net_abort(self) -> str:
         return self.event_handler_config("NetAbort")
 
     @property
+    async def async_event_net_abort(self) -> str:
+        return await self.async_event_handler_config("NetAbort")
+
+    @property
     def event_ip_conflict(self) -> str:
         return self.event_handler_config("IPConflict")
+
+    @property
+    async def async_event_ip_conflict(self) -> str:
+        return await self.async_event_handler_config("IPConflict")
 
     def event_channels_happened(self, eventcode: str) -> List[int]:
         """
@@ -125,25 +204,55 @@ class Event(Http):
             return []
         return [int(pretty(channel)) for channel in output.split()]
 
+    async def async_event_channels_happened(self, eventcode: str) -> List[int]:
+        ret = await self.async_command(
+            f"eventManager.cgi?action=getEventIndexes&code={eventcode}"
+        )
+        output = ret.content.decode()
+        if "Error" in output:
+            return []
+        return [int(pretty(channel)) for channel in output.split()]
+
     @property
     def is_motion_detected(self) -> List[int]:
         return self.event_channels_happened("VideoMotion")
+
+    @property
+    async def async_is_motion_detected(self) -> List[int]:
+        return await self.async_event_channels_happened("VideoMotion")
 
     @property
     def is_alarm_triggered(self) -> List[int]:
         return self.event_channels_happened("AlarmLocal")
 
     @property
+    async def async_is_alarm_triggered(self) -> List[int]:
+        return await self.async_event_channels_happened("AlarmLocal")
+
+    @property
     def is_human_detected(self) -> List[int]:
         return self.event_channels_happened("SmartMotionHuman")
+
+    @property
+    async def async_is_human_detected(self) -> List[int]:
+        return await self.async_event_channels_happened("SmartMotionHuman")
 
     @property
     def is_vehicle_detected(self) -> List[int]:
         return self.event_channels_happened("SmartMotionVehicle")
 
     @property
+    async def async_is_vehicle_detected(self) -> List[int]:
+        return await self.async_event_channels_happened("SmartMotionVehicle")
+
+    @property
     def event_management(self) -> str:
         ret = self.command("eventManager.cgi?action=getCaps")
+        return ret.content.decode()
+
+    @property
+    async def async_event_management(self) -> str:
+        ret = await self.async_command("eventManager.cgi?action=getCaps")
         return ret.content.decode()
 
     def event_stream(
@@ -152,7 +261,7 @@ class Event(Http):
         *,
         retries: Optional[int] = None,
         timeout_cmd: TimeoutT = None,
-    ) -> Iterable[str]:
+    ) -> Iterator[str]:
         """
         Return a stream of event info lines.
 
@@ -193,7 +302,7 @@ class Event(Http):
             ret.encoding = "utf-8"  # type: ignore[unreachable]
 
         try:
-            for line in _event_lines(ret):
+            for line in _event_lines(ret.iter_content(decode_unicode=True)):
                 if line.lower().startswith("content-length:"):
                     chunk_size = int(line.split(":")[1])
                     try:
@@ -210,36 +319,80 @@ class Event(Http):
         finally:
             ret.close()
 
+    async def async_event_stream(
+        self, eventcodes: str, *, timeout_cmd: TimeoutT = None
+    ) -> AsyncIterator[str]:
+        """Return a stream of event info lines."""
+        # If timeout is not specified, then use default, but remove read
+        # timeout since there's no telling when, if ever, an event will come.
+        if timeout_cmd is None:
+            if isinstance(self._timeout_default, tuple):
+                timeout_cmd = self._timeout_default[0], None
+            else:
+                timeout_cmd = self._timeout_default, None
+
+        async with self.async_stream_command(
+            f"eventManager.cgi?action=attach&codes=[{eventcodes}]",
+            timeout_cmd=timeout_cmd,
+        ) as ret:
+            it = ret.aiter_text(chunk_size=1)
+            async for line in _async_event_lines(it):
+                if line.lower().startswith("content-length:"):
+                    chunk_size = int(line.split(":")[1])
+                    chars = []
+                    async for char in it:
+                        chars.append(char)
+                        if len(chars) == chunk_size:
+                            break
+                    else:
+                        # If we can't get the chunk, then return out
+                        return
+                    yield "".join(chars)
+
     def event_actions(
         self,
         eventcodes: str,
         retries: Optional[int] = None,
         timeout_cmd: TimeoutT = None,
-    ) -> Iterable[Tuple[str, dict]]:
+    ) -> Iterator[Tuple[str, Dict[str, Any]]]:
         """Return a stream of event (code, payload) tuples."""
         for event_info in self.event_stream(
             eventcodes, retries=retries, timeout_cmd=timeout_cmd
         ):
-            _LOGGER.debug("%s event info: %r", self, event_info)
-            payload = {}
-            for key, value in _REG_PARSE_KEY_VALUE.findall(
-                event_info.strip().replace("\n", "")
-            ):
-                if key == "data":
-                    value = {
-                        data_key.replace('"', ""): data_value.replace('"', "")
-                        for data_key, data_value in _REG_PARSE_MALFORMED_JSON.findall(
-                            value
-                        )
-                    }
-                payload[key] = value
-            _LOGGER.debug(
-                "%s generate new event, code: %s , payload: %s",
-                self,
-                payload["Code"],
-                payload,
-            )
+            payload = self._build_payload(event_info)
             yield payload["Code"], payload
+
+    async def async_event_actions(
+        self, eventcodes: str, timeout_cmd: TimeoutT = None
+    ) -> AsyncIterator[Tuple[str, Dict[str, Any]]]:
+        """Return a stream of event (code, payload) tuples."""
+        async for event_info in self.async_event_stream(
+            eventcodes, timeout_cmd=timeout_cmd
+        ):
+            payload = self._build_payload(event_info)
+            yield payload["Code"], payload
+
+    def _build_payload(self, event_info: str) -> Dict[str, Any]:
+        _LOGGER.debug("%s event info: %r", self, event_info)
+        payload = {}
+        for key, value in _REG_PARSE_KEY_VALUE.findall(
+            event_info.strip().replace("\n", "")
+        ):
+            if key == "data":
+                value = {
+                    data_key.replace('"', ""): data_value.replace('"', "")
+                    for data_key, data_value in _REG_PARSE_MALFORMED_JSON.findall(
+                        value
+                    )
+                }
+            payload[key] = value
+        _LOGGER.debug(
+            "%s generate new event, code: %s , payload: %s",
+            self,
+            payload["Code"],
+            payload,
+        )
+        return payload
 
 
 class NoHeaderErrorFilter(logging.Filter):

--- a/src/amcrest/log.py
+++ b/src/amcrest/log.py
@@ -10,22 +10,36 @@
 # vim:sw=4:ts=4:et
 
 from datetime import datetime
-from typing import Iterator
+from typing import AsyncIterator, Iterator
 
 from .http import Http
 from .utils import date_to_str
 
 
 class Log(Http):
-    @property
     def log_clear_all(self) -> str:
         ret = self.command("log.cgi?action=clear")
+        return ret.content.decode()
+
+    async def async_log_clear_all(self) -> str:
+        ret = await self.async_command("log.cgi?action=clear")
         return ret.content.decode()
 
     def log_show(self, start_time: datetime, end_time: datetime) -> str:
         start = date_to_str(start_time)
         end = date_to_str(end_time)
         ret = self.command(
+            "Log.backup?action=All&"
+            f"condition.StartTime={start}&condition.EndTime={end}"
+        )
+        return ret.content.decode()
+
+    async def async_log_show(
+        self, start_time: datetime, end_time: datetime
+    ) -> str:
+        start = date_to_str(start_time)
+        end = date_to_str(end_time)
+        ret = await self.async_command(
             "Log.backup?action=All&"
             f"condition.StartTime={start}&condition.EndTime={end}"
         )
@@ -41,14 +55,38 @@ class Log(Http):
 
         return ret.content.decode()
 
+    async def async_log_find_start(
+        self, start_time: datetime, end_time: datetime
+    ) -> str:
+        start = date_to_str(start_time)
+        end = date_to_str(end_time)
+        ret = await self.async_command(
+            "log.cgi?action=startFind&"
+            f"condition.StartTime={start}&condition.EndTime={end}"
+        )
+
+        return ret.content.decode()
+
     def log_find_next(self, token: str, count: int = 100) -> str:
         ret = self.command(
             f"log.cgi?action=doFind&token={token}&count={count}"
         )
         return ret.content.decode()
 
+    async def async_log_find_next(self, token: str, count: int = 100) -> str:
+        ret = await self.async_command(
+            f"log.cgi?action=doFind&token={token}&count={count}"
+        )
+        return ret.content.decode()
+
     def log_find_stop(self, token: str) -> str:
         ret = self.command(f"log.cgi?action=stopFind&token={token}")
+        return ret.content.decode()
+
+    async def async_log_find_stop(self, token: str) -> str:
+        ret = await self.async_command(
+            f"log.cgi?action=stopFind&token={token}"
+        )
         return ret.content.decode()
 
     def log_find(
@@ -66,3 +104,23 @@ class Log(Http):
                 break
 
         self.log_find_stop(token)
+
+    async def async_log_find(
+        self, start_time: datetime, end_time: datetime
+    ) -> AsyncIterator[str]:
+        token = (
+            (await self.async_log_find_start(start_time, end_time))
+            .strip()
+            .split("=")[1]
+        )
+
+        while True:
+            content = await self.async_log_find_next(token)
+            tag, _, count = content.split("\r\n", 1)[0].partition("=")
+
+            yield content
+
+            if tag != "found" or int(count) == 0:
+                break
+
+        await self.async_log_find_stop(token)

--- a/src/amcrest/nas.py
+++ b/src/amcrest/nas.py
@@ -19,5 +19,9 @@ class Nas(Http):
     @property
     def nas_information(self) -> str:
         """Return NAS information."""
-        ret = self.command("configManager.cgi?action=getConfig&name=NAS")
-        return ret.content.decode()
+        return self._get_config("NAS")
+
+    @property
+    async def async_nas_information(self) -> str:
+        """Return NAS information."""
+        return await self._async_get_config("NAS")

--- a/src/amcrest/network.py
+++ b/src/amcrest/network.py
@@ -113,13 +113,15 @@ class Network(Http):
 
     @property
     def wlan_config(self) -> str:
-        ret = self.command("configManager.cgi?action=getConfig&name=WLan")
-        return ret.content.decode()
+        return self._get_config("WLan")
+
+    @property
+    async def async_wlan_config(self) -> str:
+        return await self._async_get_config("WLan")
 
     @property
     def telnet_config(self) -> str:
-        ret = self.command("configManager.cgi?action=getConfig&name=Telnet")
-        return ret.content.decode()
+        return self._get_config("Telnet")
 
     @telnet_config.setter
     def telnet_config(self, status: str) -> str:
@@ -134,13 +136,31 @@ class Network(Http):
         return ret.content.decode()
 
     @property
-    def network_config(self) -> str:
-        ret = self.command("configManager.cgi?action=getConfig&name=Network")
+    async def async_telnet_config(self) -> str:
+        return await self._async_get_config("Telnet")
+
+    async def async_set_telnet_config(self, status: str) -> str:
+        ret = await self.async_command(
+            f"configManager.cgi?action=setConfig&Telnet.Enable={status}"
+        )
         return ret.content.decode()
+
+    @property
+    def network_config(self) -> str:
+        return self._get_config("Network")
+
+    @property
+    async def async_network_config(self) -> str:
+        return await self._async_get_config("Network")
 
     @property
     def network_interfaces(self) -> str:
         ret = self.command("netApp.cgi?action=getInterfaces")
+        return ret.content.decode()
+
+    @property
+    async def async_network_interfaces(self) -> str:
+        ret = await self.async_command("netApp.cgi?action=getInterfaces")
         return ret.content.decode()
 
     @property
@@ -149,9 +169,13 @@ class Network(Http):
         return ret.content.decode()
 
     @property
-    def upnp_config(self) -> str:
-        ret = self.command("configManager.cgi?action=getConfig&name=UPnP")
+    async def async_upnp_status(self) -> str:
+        ret = await self.async_command("netApp.cgi?action=getUPnPStatus")
         return ret.content.decode()
+
+    @property
+    def upnp_config(self) -> str:
+        return self._get_config("UPnP")
 
     @upnp_config.setter
     def upnp_config(self, upnp_opt: str) -> str:
@@ -197,9 +221,18 @@ class Network(Http):
         return ret.content.decode()
 
     @property
-    def ntp_config(self) -> str:
-        ret = self.command("configManager.cgi?action=getConfig&name=NTP")
+    async def async_upnp_config(self) -> str:
+        return await self._async_get_config("UPnP")
+
+    async def async_set_upnp_config(self, upnp_opt: str) -> str:
+        ret = await self.async_command(
+            f"configManager.cgi?action=setConfig&{upnp_opt}"
+        )
         return ret.content.decode()
+
+    @property
+    def ntp_config(self) -> str:
+        return self._get_config("NTP")
 
     @ntp_config.setter
     def ntp_config(self, ntp_opt: str) -> str:
@@ -219,7 +252,21 @@ class Network(Http):
         return ret.content.decode()
 
     @property
+    async def async_ntp_config(self) -> str:
+        return await self._async_get_config("NTP")
+
+    async def async_set_ntp_config(self, ntp_opt: str) -> str:
+        ret = await self.async_command(
+            f"configManager.cgi?action=setConfig&{ntp_opt}"
+        )
+        return ret.content.decode()
+
+    @property
     def rtsp_config(self) -> str:
         """Get RTSP configuration."""
-        ret = self.command("configManager.cgi?action=getConfig&name=RTSP")
-        return ret.content.decode()
+        return self._get_config("RTSP")
+
+    @property
+    async def async_rtsp_config(self) -> str:
+        """Get RTSP configuration."""
+        return await self._async_get_config("RTSP")

--- a/src/amcrest/privacy_mode.py
+++ b/src/amcrest/privacy_mode.py
@@ -27,8 +27,14 @@ class PrivacyMode(Http):
         )
         return ret.content.decode()
 
-    def privacy_config(self) -> str:
-        ret = self.command(
-            "configManager.cgi?action=getConfig&name=LeLensMask"
+    async def async_set_privacy(self, mode: bool) -> str:
+        ret = await self.async_command(
+            f"configManager.cgi?action=setConfig&LeLensMask[0].Enable={mode}"
         )
         return ret.content.decode()
+
+    def privacy_config(self) -> str:
+        return self._get_config("LeLensMask")
+
+    async def async_privacy_config(self) -> str:
+        return await self._async_get_config("LeLensMask")

--- a/src/amcrest/ptz.py
+++ b/src/amcrest/ptz.py
@@ -19,34 +19,64 @@ ActionT = Literal["start", "stop"]
 class Ptz(Http):
     @property
     def ptz_config(self) -> str:
-        ret = self.command("configManager.cgi?action=getConfig&name=Ptz")
-        return ret.content.decode()
+        return self._get_config("Ptz")
+
+    @property
+    async def async_ptz_config(self) -> str:
+        return await self._async_get_config("Ptz")
 
     @property
     def ptz_auto_movement(self) -> str:
-        ret = self.command(
-            "configManager.cgi?action=getConfig&name=PtzAutoMovement"
-        )
-        return ret.content.decode()
+        return self._get_config("PtzAutoMovement")
+
+    @property
+    async def async_ptz_auto_movement(self) -> str:
+        return await self._async_get_config("PtzAutoMovement")
 
     def ptz_presets_list(self, *, channel: int = 0) -> str:
         ret = self.command(f"ptz.cgi?action=getPresets&channel={channel}")
+        return ret.content.decode()
+
+    async def async_ptz_presets_list(self, *, channel: int = 0) -> str:
+        ret = await self.async_command(
+            f"ptz.cgi?action=getPresets&channel={channel}"
+        )
         return ret.content.decode()
 
     @property
     def ptz_presets_count(self) -> int:
         return self.get_ptz_presets_count(channel=0)
 
+    @property
+    async def async_ptz_presets_count(self) -> int:
+        return await self.async_get_ptz_presets_count(channel=0)
+
     def get_ptz_presets_count(self, *, channel: int = 0) -> int:
         ret = self.ptz_presets_list(channel=channel)
+        return ret.count("Name=")
+
+    async def async_get_ptz_presets_count(self, *, channel: int = 0) -> int:
+        ret = await self.async_ptz_presets_list(channel=channel)
         return ret.count("Name=")
 
     def ptz_status(self, *, channel: int = 0) -> str:
         ret = self.command(f"ptz.cgi?action=getStatus&channel={channel}")
         return ret.content.decode()
 
+    async def async_ptz_status(self, *, channel: int = 0) -> str:
+        ret = await self.async_command(
+            f"ptz.cgi?action=getStatus&channel={channel}"
+        )
+        return ret.content.decode()
+
     def ptz_tour_routines_list(self, *, channel: int = 0) -> str:
         ret = self.command(
+            f"configManager.cgi?action=getTours&channel={channel}"
+        )
+        return ret.content.decode()
+
+    async def async_ptz_tour_routines_list(self, *, channel: int = 0) -> str:
+        ret = await self.async_command(
             f"configManager.cgi?action=getTours&channel={channel}"
         )
         return ret.content.decode()
@@ -67,6 +97,22 @@ class Ptz(Http):
         )
         return ret.content.decode().strip() == "OK"
 
+    async def async_ptz_control_command(
+        self,
+        action: ActionT,
+        code: str,
+        *,
+        arg1: str = "0",
+        arg2: str = "0",
+        arg3: str = "0",
+        channel: int = 0,
+    ) -> bool:
+        ret = await self.async_command(
+            f"ptz.cgi?action={action}&channel={channel}&code={code}&"
+            f"arg1={arg1}&arg2={arg2}&arg3={arg3}"
+        )
+        return ret.content.decode().strip() == "OK"
+
     def zoom_in(self, start: bool, *, channel: int = 0) -> bool:
         """
         Params:
@@ -77,6 +123,21 @@ class Ptz(Http):
         'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.5 sec
         """
         return self.ptz_control_command(
+            action="start" if start else "stop",
+            code="ZoomTele",
+            channel=channel,
+        )
+
+    async def async_zoom_in(self, start: bool, *, channel: int = 0) -> bool:
+        """
+        Params:
+            start               - True to start, False to stop
+            channel             - channel number
+
+        The magic of zoom in 1x, 2x etc. is the timer between the cmd
+        'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.5 sec
+        """
+        return await self.async_ptz_control_command(
             action="start" if start else "stop",
             code="ZoomTele",
             channel=channel,
@@ -97,6 +158,21 @@ class Ptz(Http):
             channel=channel,
         )
 
+    async def async_zoom_out(self, start: bool, *, channel: int = 0) -> bool:
+        """
+        Params:
+            start               - True to start, False to stop
+            channel             - channel number
+
+        The magic of zoom out 1x, 2x etc. is the timer between the cmd
+        'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.5 sec
+        """
+        return await self.async_ptz_control_command(
+            action="start" if start else "stop",
+            code="ZoomWide",
+            channel=channel,
+        )
+
     def move_left(
         self, start: bool, *, channel: int = 0, horizontal_speed: int = 1
     ) -> bool:
@@ -110,6 +186,25 @@ class Ptz(Http):
         'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.5 sec
         """
         return self.ptz_control_command(
+            action="start" if start else "stop",
+            code="Left",
+            arg2=str(horizontal_speed),
+            channel=channel,
+        )
+
+    async def async_move_left(
+        self, start: bool, *, channel: int = 0, horizontal_speed: int = 1
+    ) -> bool:
+        """
+        Params:
+            start               - True to start, False to stop
+            channel             - channel number
+            horizontal_speed    - range 1-8
+
+        The magic of move left 1x, 2x etc. is the timer between the cmd
+        'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.5 sec
+        """
+        return await self.async_ptz_control_command(
             action="start" if start else "stop",
             code="Left",
             arg2=str(horizontal_speed),
@@ -135,6 +230,25 @@ class Ptz(Http):
             channel=channel,
         )
 
+    async def async_move_right(
+        self, start: bool, *, channel: int = 0, horizontal_speed: int = 1
+    ) -> bool:
+        """
+        Params:
+            start               - True to start, False to stop
+            channel             - channel number
+            horizontal_speed    - range 1-8
+
+        The magic of move right 1x, 2x etc. is the timer between the cmd
+        'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.5 sec
+        """
+        return await self.async_ptz_control_command(
+            action="start" if start else "stop",
+            code="Right",
+            arg2=str(horizontal_speed),
+            channel=channel,
+        )
+
     def move_up(
         self, start: bool, *, channel: int = 0, vertical_speed: int = 1
     ) -> bool:
@@ -154,6 +268,25 @@ class Ptz(Http):
             channel=channel,
         )
 
+    async def async_move_up(
+        self, start: bool, *, channel: int = 0, vertical_speed: int = 1
+    ) -> bool:
+        """
+        Params:
+            start               - True to start, False to stop
+            channel             - channel number
+            vertical_speed      - range 1-8
+
+        The magic of move up 1x, 2x etc. is the timer between the cmd
+        'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.2 sec
+        """
+        return await self.async_ptz_control_command(
+            action="start" if start else "stop",
+            code="Up",
+            arg2=str(vertical_speed),
+            channel=channel,
+        )
+
     def move_down(
         self, start: bool, *, channel: int = 0, vertical_speed: int = 1
     ) -> bool:
@@ -162,6 +295,20 @@ class Ptz(Http):
         'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.2 sec
         """
         return self.ptz_control_command(
+            action="start" if start else "stop",
+            code="Down",
+            arg2=str(vertical_speed),
+            channel=channel,
+        )
+
+    async def async_move_down(
+        self, start: bool, *, channel: int = 0, vertical_speed: int = 1
+    ) -> bool:
+        """
+        The magic of move down 1x, 2x etc. is the timer between the cmd
+        'start' and cmd 'stop'. My suggestion for start/stop cmd is 0.2 sec
+        """
+        return await self.async_ptz_control_command(
             action="start" if start else "stop",
             code="Down",
             arg2=str(vertical_speed),
@@ -193,6 +340,31 @@ class Ptz(Http):
             channel=channel,
         )
 
+    async def async_position_abs(
+        self,
+        start: bool,
+        *,
+        horizontal_angle: int = 0,
+        vertical_angle: int = 0,
+        channel: int = 0,
+    ) -> bool:
+        """
+        Params:
+            start               - True to start, False to stop
+            horizontal_angle    - range 0-360
+            vertical_angle      - range 0-360
+            channel             - channel number
+
+        Go to an absolute coordinate
+        """
+        return await self.async_ptz_control_command(
+            action="start" if start else "stop",
+            code="PositionABS",
+            arg1=str(horizontal_angle),
+            arg2=str(vertical_angle),
+            channel=channel,
+        )
+
     def focus_near(self, start: bool, *, channel: int = 0) -> bool:
         """
         Params:
@@ -205,6 +377,18 @@ class Ptz(Http):
             channel=channel,
         )
 
+    async def async_focus_near(self, start: bool, *, channel: int = 0) -> bool:
+        """
+        Params:
+            start               - True to start, False to stop
+            channel             - channel number
+        """
+        return await self.async_ptz_control_command(
+            action="start" if start else "stop",
+            code="FocusNear",
+            channel=channel,
+        )
+
     def focus_far(self, start: bool, *, channel: int = 0) -> bool:
         """
         Params:
@@ -212,6 +396,18 @@ class Ptz(Http):
             channel             - channel number
         """
         return self.ptz_control_command(
+            action="start" if start else "stop",
+            code="FocusFar",
+            channel=channel,
+        )
+
+    async def async_focus_far(self, start: bool, *, channel: int = 0) -> bool:
+        """
+        Params:
+            start               - True to start, False to stop
+            channel             - channel number
+        """
+        return await self.async_ptz_control_command(
             action="start" if start else "stop",
             code="FocusFar",
             channel=channel,
@@ -231,6 +427,20 @@ class Ptz(Http):
             channel=channel,
         )
 
+    async def async_iris_large(self, start: bool, *, channel: int = 0) -> bool:
+        """
+        Aperture larger
+
+        Params:
+            start               - True to start, False to stop
+            channel             - channel number
+        """
+        return await self.async_ptz_control_command(
+            action="start" if start else "stop",
+            code="IrisLarge",
+            channel=channel,
+        )
+
     def iris_small(self, start: bool, *, channel: int = 0) -> bool:
         """
         Aperture smaller
@@ -240,6 +450,20 @@ class Ptz(Http):
             channel             - channel number
         """
         return self.ptz_control_command(
+            action="start" if start else "stop",
+            code="IrisSmall",
+            channel=channel,
+        )
+
+    async def async_iris_small(self, start: bool, *, channel: int = 0) -> bool:
+        """
+        Aperture smaller
+
+        Params:
+            start               - True to start, False to stop
+            channel             - channel number
+        """
+        return await self.async_ptz_control_command(
             action="start" if start else "stop",
             code="IrisSmall",
             channel=channel,
@@ -260,6 +484,21 @@ class Ptz(Http):
             channel=channel,
         )
 
+    async def async_go_to_preset(
+        self, *, channel: int = 0, preset_point_number: int = 1
+    ) -> bool:
+        """
+        Params:
+            channel             - channel number
+            preset_point_number - preset point number
+        """
+        return await self.async_ptz_control_command(
+            action="start",
+            code="GotoPreset",
+            arg2=str(preset_point_number),
+            channel=channel,
+        )
+
     def set_preset(
         self, *, channel: int = 0, preset_point_number: int = 1
     ) -> bool:
@@ -269,6 +508,21 @@ class Ptz(Http):
             preset_point_number - preset point number
         """
         return self.ptz_control_command(
+            action="start",
+            code="SetPreset",
+            arg2=str(preset_point_number),
+            channel=channel,
+        )
+
+    async def async_set_preset(
+        self, *, channel: int = 0, preset_point_number: int = 1
+    ) -> bool:
+        """
+        Params:
+            channel             - channel number
+            preset_point_number - preset point number
+        """
+        return await self.async_ptz_control_command(
             action="start",
             code="SetPreset",
             arg2=str(preset_point_number),
@@ -295,6 +549,26 @@ class Ptz(Http):
             channel=channel,
         )
 
+    async def async_tour(
+        self,
+        start: bool = True,
+        *,
+        channel: int = 0,
+        tour_path_number: int = 1,
+    ) -> bool:
+        """
+        Params:
+            start               - True (StartTour) or False (StopTour)
+            channel             - channel number
+            tour_path_number    - tour path number
+        """
+        return await self.async_ptz_control_command(
+            action="start",
+            code="StartTour" if start else "StopTour",
+            arg1=str(tour_path_number),
+            channel=channel,
+        )
+
     def move_left_up(
         self,
         start: bool,
@@ -311,6 +585,29 @@ class Ptz(Http):
             horizontal_speed - range is 1-8
         """
         return self.ptz_control_command(
+            action="start" if start else "stop",
+            code="LeftUp",
+            arg1=str(vertical_speed),
+            arg2=str(horizontal_speed),
+            channel=channel,
+        )
+
+    async def async_move_left_up(
+        self,
+        start: bool,
+        *,
+        channel: int = 0,
+        vertical_speed: int = 1,
+        horizontal_speed: int = 1,
+    ) -> bool:
+        """
+        Params:
+            start            - True to start, False to stop
+            channel          - channel number
+            vertical_speed   - range is 1-8
+            horizontal_speed - range is 1-8
+        """
+        return await self.async_ptz_control_command(
             action="start" if start else "stop",
             code="LeftUp",
             arg1=str(vertical_speed),
@@ -341,6 +638,29 @@ class Ptz(Http):
             channel=channel,
         )
 
+    async def async_move_left_down(
+        self,
+        start: bool,
+        *,
+        channel: int = 0,
+        vertical_speed: int = 1,
+        horizontal_speed: int = 1,
+    ) -> bool:
+        """
+        Params:
+            start            - True to start, False to stop
+            channel          - channel number
+            vertical_speed   - range is 1-8
+            horizontal_speed - range is 1-8
+        """
+        return await self.async_ptz_control_command(
+            action="start" if start else "stop",
+            code="LeftDown",
+            arg1=str(vertical_speed),
+            arg2=str(horizontal_speed),
+            channel=channel,
+        )
+
     def move_right_up(
         self,
         start: bool,
@@ -357,6 +677,29 @@ class Ptz(Http):
             horizontal_speed - range is 1-8
         """
         return self.ptz_control_command(
+            action="start" if start else "stop",
+            code="RightUp",
+            arg1=str(vertical_speed),
+            arg2=str(horizontal_speed),
+            channel=channel,
+        )
+
+    async def async_move_right_up(
+        self,
+        start: bool,
+        *,
+        channel: int = 0,
+        vertical_speed: int = 1,
+        horizontal_speed: int = 1,
+    ) -> bool:
+        """
+        Params:
+            start            - True to start, False to stop
+            channel          - channel number
+            vertical_speed   - range is 1-8
+            horizontal_speed - range is 1-8
+        """
+        return await self.async_ptz_control_command(
             action="start" if start else "stop",
             code="RightUp",
             arg1=str(vertical_speed),
@@ -387,6 +730,29 @@ class Ptz(Http):
             channel=channel,
         )
 
+    async def async_move_right_down(
+        self,
+        start: bool,
+        *,
+        channel: int = 0,
+        vertical_speed: int = 1,
+        horizontal_speed: int = 1,
+    ) -> bool:
+        """
+        Params:
+            start            - True to start, False to stop
+            channel          - channel number
+            vertical_speed   - range is 1-8
+            horizontal_speed - range is 1-8
+        """
+        return await self.async_ptz_control_command(
+            action="start" if start else "stop",
+            code="RightDown",
+            arg1=str(vertical_speed),
+            arg2=str(horizontal_speed),
+            channel=channel,
+        )
+
     def move_directly(
         self,
         startpoint_x: int,
@@ -406,6 +772,31 @@ class Ptz(Http):
             startX, startY, endX and endY - range is 0-8192
         """
         ret = self.command(
+            f"ptzBase.cgi?action=moveDirectly&channel={channel}&"
+            f"startPoint[0]={startpoint_x}&startPoint[1]={startpoint_y}&"
+            f"endPoint[0]={endpoint_x}&endPoint[1]={endpoint_y}"
+        )
+        return ret.content.decode()
+
+    async def async_move_directly(
+        self,
+        startpoint_x: int,
+        startpoint_y: int,
+        endpoint_x: int,
+        endpoint_y: int,
+        *,
+        channel: int = 1,
+    ) -> str:
+        """
+
+        Three-dimensional orientation. Move to the rectangle with screen
+        coordinate [startX, startY], [endX, endY]
+
+        Params:
+            channel          - channel index, start with 1
+            startX, startY, endX and endY - range is 0-8192
+        """
+        ret = await self.async_command(
             f"ptzBase.cgi?action=moveDirectly&channel={channel}&"
             f"startPoint[0]={startpoint_x}&startPoint[1]={startpoint_y}&"
             f"endPoint[0]={endpoint_x}&endPoint[1]={endpoint_y}"

--- a/src/amcrest/snapshot.py
+++ b/src/amcrest/snapshot.py
@@ -23,15 +23,13 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Snapshot(Http):
-    def __get_config(self, config_name: str) -> str:
-        ret = self.command(
-            f"configManager.cgi?action=getConfig&name={config_name}"
-        )
-        return ret.content.decode()
-
     @property
     def snapshot_config(self) -> str:
-        return self.__get_config("Snap")
+        return self._get_config("Snap")
+
+    @property
+    async def async_snapshot_config(self) -> str:
+        return await self._async_get_config("Snap")
 
     @overload
     def snapshot(
@@ -101,3 +99,13 @@ class Snapshot(Http):
                     out_file.write(ret.content)
 
         return ret.raw if stream else ret.content
+
+    async def async_snapshot(
+        self, *, channel: Optional[int] = None, timeout: TimeoutT = None
+    ) -> bytes:
+        cmd = "snapshot.cgi"
+        if channel is not None:
+            cmd += f"?channel={channel}"
+        ret = await self.async_command(cmd, timeout_cmd=timeout)
+
+        return ret.content

--- a/src/amcrest/special.py
+++ b/src/amcrest/special.py
@@ -71,12 +71,23 @@ class Special(Http):
                     1-Extra Stream 1 (Sub Stream)
                     2-Extra Stream 2 (Sub Stream)
         """
+        return self._build_rtsp_url(self.rtsp_config, channel, typeno)  # type: ignore[attr-defined]
+
+    async def async_rtsp_url(
+        self, *, channel: int = 1, typeno: int = 0
+    ) -> str:
+        rtsp_config = await self.async_rtsp_config  # type: ignore[attr-defined]
+        return self._build_rtsp_url(rtsp_config, channel, typeno)
+
+    def _build_rtsp_url(
+        self, rtsp_config: str, channel: int, typeno: int
+    ) -> str:
         cmd = f"cam/realmonitor?channel={channel}&subtype={typeno}"
 
         try:
             port_num = [
                 x.split("=")[1]
-                for x in self.rtsp_config.split()  # type: ignore[attr-defined]
+                for x in rtsp_config.split()
                 if x.startswith("table.RTSP.Port=")
             ][0]
         except IndexError:

--- a/src/amcrest/user_management.py
+++ b/src/amcrest/user_management.py
@@ -15,37 +15,46 @@ from .http import Http
 
 class UserManagement(Http):
     def info_user(self, username: str) -> str:
-        ret = self.command(
-            "userManager.cgi?action=getUserInfo&name={0}".format(username)
-        )
-        return ret.content.decode()
+        return self._user_manager(f"getUserInfo&name={username}")
+
+    async def async_info_user(self, username: str) -> str:
+        return await self._async_user_manager(f"getUserInfo&name={username}")
 
     @property
     def info_all_users(self) -> str:
-        ret = self.command("userManager.cgi?action=getUserInfoAll")
-        return ret.content.decode()
+        return self._user_manager("getUserInfoAll")
+
+    @property
+    async def async_info_all_users(self) -> str:
+        return await self._async_user_manager("getUserInfoAll")
 
     @property
     def info_all_active_users(self) -> str:
-        ret = self.command("userManager.cgi?action=getActiveUserInfoAll")
-        return ret.content.decode()
+        return self._user_manager("getActiveUserInfoAll")
+
+    @property
+    async def async_info_all_active_users(self) -> str:
+        return await self._async_user_manager("getActiveUserInfoAll")
 
     def info_group(self, group: str) -> str:
-        ret = self.command(
-            "userManager.cgi?action=getGroupInfo&name={0}".format(group)
-        )
-        return ret.content.decode()
+        return self._user_manager(f"getGroupInfo&name={group}")
+
+    async def async_info_group(self, group: str) -> str:
+        return await self._async_user_manager(f"getGroupInfo&name={group}")
 
     @property
     def info_all_groups(self) -> str:
-        ret = self.command("userManager.cgi?action=getGroupInfoAll")
-        return ret.content.decode()
+        return self._user_manager("getGroupInfoAll")
+
+    @property
+    async def async_info_all_groups(self) -> str:
+        return await self._async_user_manager("getGroupInfoAll")
 
     def delete_user(self, username: str) -> str:
-        ret = self.command(
-            "userManager.cgi?action=deleteUser&name={0}".format(username)
-        )
-        return ret.content.decode()
+        return self._user_manager(f"deleteUser&name={username}")
+
+    async def async_delete_user(self, username: str) -> str:
+        return await self._async_user_manager(f"deleteUser&name={username}")
 
     def add_user(
         self,
@@ -71,22 +80,41 @@ class UserManagement(Http):
         """
 
         cmd = (
-            "userManager.cgi?action=addUser&user.Name={0}"
-            "&user.Password={1}&user.Group={2}&user.Sharable={3}"
-            "&user.Reserved={4}".format(
-                username,
-                password,
-                group.lower(),
-                str(sharable).lower(),
-                str(reserved).lower(),
-            )
+            "addUser"
+            f"&user.Name={username}"
+            f"&user.Password={password}"
+            f"&user.Group={group.lower()}"
+            f"&user.Sharable={str(sharable).lower()}"
+            f"&user.Reserved={str(reserved).lower()}"
         )
 
         if memo:
-            cmd += "&user.Memo=%s" % memo
+            cmd += f"&user.Memo={memo}"
 
-        ret = self.command(cmd)
-        return ret.content.decode()
+        return self._user_manager(cmd)
+
+    async def async_add_user(
+        self,
+        username: str,
+        password: str,
+        group: str,
+        sharable: bool = True,
+        reserved: bool = False,
+        memo: Optional[str] = None,
+    ) -> str:
+        cmd = (
+            "addUser"
+            f"&user.Name={username}"
+            f"&user.Password={password}"
+            f"&user.Group={group.lower()}"
+            f"&user.Sharable={str(sharable).lower()}"
+            f"&user.Reserved={str(reserved).lower()}"
+        )
+
+        if memo:
+            cmd += f"&user.Memo={memo}"
+
+        return await self._async_user_manager(cmd)
 
     def modify_password(self, username: str, newpwd: str, oldpwd: str) -> str:
         """
@@ -95,11 +123,16 @@ class UserManagement(Http):
             newpwd - new password
             oldpwd - old password
         """
-        ret = self.command(
-            "userManager.cgi?action=modifyPassword&name={0}&pwd={1}"
-            "&pwdOld={2}".format(username, newpwd, oldpwd)
+        return self._user_manager(
+            f"modifyPassword&name={username}&pwd={newpwd}&pwdOld={oldpwd}"
         )
-        return ret.content.decode()
+
+    async def async_modify_password(
+        self, username: str, newpwd: str, oldpwd: str
+    ) -> str:
+        return await self._async_user_manager(
+            f"modifyPassword&name={username}&pwd={newpwd}&pwdOld={oldpwd}"
+        )
 
     def modify_user(self, username: str, attribute: str, value: str) -> str:
         """
@@ -111,19 +144,45 @@ class UserManagement(Http):
             value - the new value for attribute
         """
 
-        cmd = "userManager.cgi?action=modifyUser&name={0}".format(username)
+        cmd = f"modifyUser&name={username}"
 
         if attribute.lower() == "group":
-            cmd += "&user.Group=%s" % value.lower()
+            cmd += f"&user.Group={value.lower()}"
 
         elif attribute.lower() == "sharable":
-            cmd += "&user.Sharable=%s" % value.lower()
+            cmd += f"&user.Sharable={value.lower()}"
 
         elif attribute.lower() == "reserved":
-            cmd += "&user.Reserved=%s" % value.lower()
+            cmd += f"&user.Reserved={value.lower()}"
 
         elif attribute == "memo":
-            cmd += "&user.Memo=%s" % value.lower()
+            cmd += f"&user.Memo={value.lower()}"
 
-        ret = self.command(cmd)
+        return self._user_manager(cmd)
+
+    async def async_modify_user(
+        self, username: str, attribute: str, value: str
+    ) -> str:
+        cmd = f"modifyUser&name={username}"
+
+        if attribute.lower() == "group":
+            cmd += f"&user.Group={value.lower()}"
+
+        elif attribute.lower() == "sharable":
+            cmd += f"&user.Sharable={value.lower()}"
+
+        elif attribute.lower() == "reserved":
+            cmd += f"&user.Reserved={value.lower()}"
+
+        elif attribute == "memo":
+            cmd += f"&user.Memo={value.lower()}"
+
+        return await self._async_user_manager(cmd)
+
+    def _user_manager(self, action: str) -> str:
+        ret = self.command(f"userManager.cgi?action={action}")
+        return ret.content.decode()
+
+    async def _async_user_manager(self, action: str) -> str:
+        ret = await self.async_command(f"userManager.cgi?action={action}")
         return ret.content.decode()

--- a/src/amcrest/utils.py
+++ b/src/amcrest/utils.py
@@ -56,13 +56,17 @@ def str2bool(value: Union[str, int]) -> bool:
     return bool(value)
 
 
-def to_unit(value: Union[str, int, float], unit: str = "B") -> Tuple[str, str]:
+def to_unit(
+    value: Union[None, str, int, float], unit: str = "B"
+) -> Tuple[str, str]:
     """Convert bytes to give unit."""
     byte_array = ["B", "KB", "MB", "GB", "TB"]
 
     if unit not in byte_array:
         raise ValueError(f"Unit {unit} missing from known units")
 
+    if value is None:
+        return "unknown", unit
     if isinstance(value, (int, float)):
         value_f = value
     else:

--- a/src/amcrest/video.py
+++ b/src/amcrest/video.py
@@ -18,21 +18,32 @@ from .http import Http
 class Video(Http):
     @property
     def video_max_extra_streams(self) -> int:
-        ret = self.command(
-            "magicBox.cgi?action=getProductDefinition&name=MaxExtraStream"
+        ret = self._magic_box("getProductDefinition&name=MaxExtraStream")
+        return int(utils.pretty(ret))
+
+    @property
+    async def async_video_max_extra_streams(self) -> int:
+        ret = await self._async_magic_box(
+            "getProductDefinition&name=MaxExtraStream"
         )
-        return int(utils.pretty(ret.content.decode()))
+        return int(utils.pretty(ret))
 
     @property
     def video_color_config(self) -> str:
-        ret = self.command(
-            "configManager.cgi?action=getConfig&name=VideoColor"
-        )
-        return ret.content.decode()
+        return self._get_config("VideoColor")
+
+    @property
+    async def async_video_color_config(self) -> str:
+        return await self._async_get_config("VideoColor")
 
     @property
     def encode_capability(self) -> str:
         ret = self.command("encode.cgi?action=getCaps")
+        return ret.content.decode()
+
+    @property
+    async def async_encode_capability(self) -> str:
+        ret = await self.async_command("encode.cgi?action=getCaps")
         return ret.content.decode()
 
     def encode_config_capability(self, channel: int) -> str:
@@ -41,29 +52,45 @@ class Video(Http):
         )
         return ret.content.decode()
 
+    async def async_encode_config_capability(self, channel: int) -> str:
+        ret = await self.async_command(
+            f"encode.cgi?action=getConfigCaps&channel={channel}"
+        )
+        return ret.content.decode()
+
     @property
     def encode_media(self) -> str:
-        ret = self.command("configManager.cgi?action=getConfig&name=Encode")
-        return ret.content.decode()
+        return self._get_config("Encode")
+
+    @property
+    async def async_encode_media(self) -> str:
+        return await self._async_get_config("Encode")
 
     @property
     def encode_region_interested(self) -> str:
-        ret = self.command(
-            "configManager.cgi?action=getConfig&name=VideoEncodeROI"
-        )
-        return ret.content.decode()
+        return self._get_config("VideoEncodeROI")
+
+    @property
+    async def async_encode_region_interested(self) -> str:
+        return await self._async_get_config("VideoEncodeROI")
 
     @property
     def video_channel_title(self) -> str:
-        ret = self.command(
-            "configManager.cgi?action=getConfig&name=ChannelTitle"
-        )
-        return ret.content.decode()
+        return self._get_config("ChannelTitle")
+
+    @property
+    async def async_video_channel_title(self) -> str:
+        return await self._async_get_config("ChannelTitle")
 
     # pylint: disable=invalid-name
     @property
     def video_input_channels_device_supported(self) -> str:
         ret = self.command("devVideoInput.cgi?action=getCollect")
+        return ret.content.decode()
+
+    @property
+    async def async_video_input_channels_device_supported(self) -> str:
+        ret = await self.async_command("devVideoInput.cgi?action=getCollect")
         return ret.content.decode()
 
     # pylint: disable=invalid-name
@@ -72,38 +99,55 @@ class Video(Http):
         ret = self.command("devVideoOutput.cgi?action=getCollect")
         return ret.content.decode()
 
+    @property
+    async def async_video_output_channels_device_supported(self) -> str:
+        ret = await self.async_command("devVideoOutput.cgi?action=getCollect")
+        return ret.content.decode()
+
     # pylint: disable=invalid-name
     @property
     def video_max_remote_input_channels(self) -> str:
-        ret = self.command(
-            "magicBox.cgi?action=getProductDefinition&name="
-            "MaxRemoteInputChannels"
+        return self._magic_box(
+            "getProductDefinition&name=MaxRemoteInputChannels"
         )
-        return ret.content.decode()
+
+    @property
+    async def async_video_max_remote_input_channels(self) -> str:
+        return await self._async_magic_box(
+            "getProductDefinition&name=MaxRemoteInputChannels"
+        )
 
     @property
     def video_standard(self) -> str:
-        ret = self.command(
-            "configManager.cgi?action=getConfig&name=VideoStandard"
-        )
-        return ret.content.decode()
+        return self._get_config("VideoStandard")
 
     @video_standard.setter
     def video_standard(self, std: str) -> str:
-        ret = self.command(
-            f"configManager.cgi?action=setConfig&VideoStandard={std}"
-        )
-        return ret.content.decode()
+        return self._get_config(f"setConfig&VideoStandard={std}")
+
+    @property
+    async def async_video_standard(self) -> str:
+        return await self._async_get_config("VideoStandard")
+
+    async def async_set_video_standard(self, std: str) -> str:
+        return await self._async_get_config(f"setConfig&VideoStandard={std}")
 
     @property
     def video_widget_config(self) -> str:
-        ret = self.command(
-            "configManager.cgi?action=getConfig&name=VideoWidget"
-        )
-        return ret.content.decode()
+        return self._get_config("VideoWidget")
+
+    @property
+    async def async_video_widget_config(self) -> str:
+        return await self._async_get_config("VideoWidget")
 
     def video_input_capability(self, channel: int) -> str:
         ret = self.command(
+            f"devVideoInput.cgi?action=getCaps&channel={channel}"
+        )
+        return ret.content.decode()
+
+    async def async_video_input_capability(self, channel: int) -> str:
+        ret = await self.async_command(
             f"devVideoInput.cgi?action=getCaps&channel={channel}"
         )
         return ret.content.decode()
@@ -114,12 +158,21 @@ class Video(Http):
         )
         return ret.content.decode()
 
-    @property
-    def video_in_options(self) -> str:
-        ret = self.command(
-            "configManager.cgi?action=getConfig&name=VideoInOptions"
+    async def async_video_coordinates_current_window(
+        self, channel: int
+    ) -> str:
+        ret = await self.async_command(
+            f"devVideoInput.cgi?action=getCurrentWindow&channel={channel}"
         )
         return ret.content.decode()
+
+    @property
+    def video_in_options(self) -> str:
+        return self._get_config("VideoInOptions")
+
+    @property
+    async def async_video_in_options(self) -> str:
+        return await self._async_get_config("VideoInOptions")
 
     def video_in_option(
         self, param: str, *, profile: str = "Day"
@@ -141,6 +194,26 @@ class Video(Http):
             if f"].{field}=" in opt
         ]
 
+    async def async_video_in_option(
+        self, param: str, *, profile: str = "Day"
+    ) -> List[str]:
+        """
+        Return video input option.
+
+        Params:
+            param - parameter, such as 'DayNightColor'
+            profile - 'Day', 'Night' or 'Normal'
+        """
+        if profile == "Day":
+            field = param
+        else:
+            field = f"{profile}Options.{param}"
+        return [
+            utils.pretty(opt)
+            for opt in (await self.async_video_in_options).split()
+            if f"].{field}=" in opt
+        ]
+
     def set_video_in_option(
         self, param: str, value: str, *, profile: str = "Day", channel: int = 0
     ) -> str:
@@ -154,6 +227,39 @@ class Video(Http):
         )
         return ret.content.decode()
 
+    async def async_set_video_in_option(
+        self, param: str, value: str, *, profile: str = "Day", channel: int = 0
+    ) -> str:
+        if profile == "Day":
+            field = param
+        else:
+            field = f"{profile}Options.{param}"
+        ret = await self.async_command(
+            "configManager.cgi?action=setConfig"
+            f"&VideoInOptions[{channel}].{field}={value}"
+        )
+        return ret.content.decode()
+
+    @property
+    def day_night_color(self) -> int:
+        """
+        Return Day & Night Color Mode for Day profile.
+
+        Result is 0: always multicolor
+                  1: autoswitch along with brightness
+                  2: always monochrome
+        """
+        return self.get_day_night_color(channel=0)
+
+    @day_night_color.setter
+    def day_night_color(self, value: int) -> str:
+        return self.set_video_in_option("DayNightColor", str(value), channel=0)
+
+    @property
+    async def async_day_night_color(self) -> int:
+        """Return Day & Night Color Mode for Day profile."""
+        return await self.async_get_day_night_color(channel=0)
+
     def get_day_night_color(self, channel: int) -> int:
         """
         Return Day & Night Color Mode for Day profile.
@@ -165,14 +271,52 @@ class Video(Http):
         values = [int(x) for x in self.video_in_option("DayNightColor")]
         return values[channel]
 
+    async def async_get_day_night_color(self, channel: int) -> int:
+        """
+        Return Day & Night Color Mode for Day profile.
+
+        Result is 0: always multicolor
+                  1: autoswitch along with brightness
+                  2: always monochrome
+        """
+        values = [
+            int(x) for x in await self.async_video_in_option("DayNightColor")
+        ]
+        return values[channel]
+
     def set_day_night_color(self, value: int, channel: int) -> str:
         return self.set_video_in_option(
             "DayNightColor", str(value), channel=channel
         )
 
+    async def async_set_day_night_color(self, value: int, channel: int) -> str:
+        return await self.async_set_video_in_option(
+            "DayNightColor", str(value), channel=channel
+        )
+
+    @property
+    def smart_ir(self) -> bool:
+        """Return if SmartIR is on."""
+        return self.is_smart_ir_on(channel=0)
+
+    @smart_ir.setter
+    def smart_ir(self, value: bool) -> str:
+        return self.set_smart_ir(value, channel=0)
+
+    @property
+    async def async_smart_ir(self) -> bool:
+        """Return if SmartIR is on."""
+        return await self.async_is_smart_ir_on(channel=0)
+
     def is_smart_ir_on(self, channel: int) -> bool:
         """Return if SmartIR is on."""
         return self.video_in_option("InfraRed")[channel] == "false"
+
+    async def async_is_smart_ir_on(self, channel: int) -> bool:
+        """Return if SmartIR is on."""
+        return (await self.async_video_in_option("InfraRed"))[
+            channel
+        ] == "false"
 
     def set_smart_ir(self, value: bool, channel: int) -> str:
         # It's not clear why from the HTTP API SDK doc, but setting InfraRed
@@ -182,6 +326,31 @@ class Video(Http):
         # via the HTTP API.
         str_value = "false" if value else "true"
         return self.set_video_in_option("InfraRed", str_value, channel=channel)
+
+    async def async_set_smart_ir(self, value: bool, channel: int) -> str:
+        # It's not clear why from the HTTP API SDK doc, but setting InfraRed
+        # to false sets the Night Vision Mode to SmartIR, whereas setting it
+        # to true sets the Night Vision Mode to OFF. Night Vision Mode has a
+        # third setting of Manual, but that must be selected some other way
+        # via the HTTP API.
+        str_value = "false" if value else "true"
+        return await self.async_set_video_in_option(
+            "InfraRed", str_value, channel=channel
+        )
+
+    @property
+    def video_enabled(self) -> bool:
+        """Return if main video stream enabled."""
+        return self.is_video_enabled(channel=0)
+
+    @video_enabled.setter
+    def video_enabled(self, enable: bool) -> None:
+        self.set_video_enabled(enable, channel=0)
+
+    @property
+    async def async_video_enabled(self) -> bool:
+        """Return if main video stream enabled."""
+        return await self.async_is_video_enabled(channel=0)
 
     def is_video_enabled(
         self, channel: int, *, stream: str = "Main", stream_type: int = 0
@@ -201,44 +370,32 @@ class Video(Http):
         )
         return is_enabled[channel]
 
+    async def async_is_video_enabled(
+        self, channel: int, *, stream: str = "Main", stream_type: int = 0
+    ) -> bool:
+        """Return if given video stream enabled."""
+        is_enabled = utils.extract_audio_video_enabled(
+            f"{stream}Format[{stream_type}].Video",
+            await self.async_encode_media,
+        )
+        return is_enabled[channel]
+
     def set_video_enabled(self, enable: bool, channel: int) -> None:
         self.command(utils.enable_audio_video_cmd("Video", enable, channel))
         self.set_smart_ir(enable, channel)
 
-    @property
-    def day_night_color(self) -> int:
-        """
-        Return Day & Night Color Mode for Day profile.
-
-        Result is 0: always multicolor
-                  1: autoswitch along with brightness
-                  2: always monochrome
-        """
-        return self.get_day_night_color(channel=0)
-
-    @day_night_color.setter
-    def day_night_color(self, value: int) -> str:
-        return self.set_video_in_option("DayNightColor", str(value), channel=0)
-
-    @property
-    def smart_ir(self) -> bool:
-        """Return if SmartIR is on."""
-        return self.is_smart_ir_on(channel=0)
-
-    @smart_ir.setter
-    def smart_ir(self, value: bool) -> str:
-        return self.set_smart_ir(value, channel=0)
-
-    @property
-    def video_enabled(self) -> bool:
-        """Return if main video stream enabled."""
-        return self.is_video_enabled(channel=0)
-
-    @video_enabled.setter
-    def video_enabled(self, enable: bool) -> None:
-        self.set_video_enabled(enable, channel=0)
+    async def async_set_video_enabled(
+        self, enable: bool, channel: int
+    ) -> None:
+        await self.async_command(
+            utils.enable_audio_video_cmd("Video", enable, channel)
+        )
+        await self.async_set_smart_ir(enable, channel)
 
     @property
     def video_out_options(self) -> str:
-        ret = self.command("configManager.cgi?action=getConfig&name=VideoOut")
-        return ret.content.decode()
+        return self._get_config("VideoOut")
+
+    @property
+    async def async_video_out_options(self) -> str:
+        return await self._async_get_config("VideoOut")


### PR DESCRIPTION
Add a full suite of API functions that are able to use asyncio-based
calls.  The async http requests are provided through httpx, which is
able to provide both basic auth and digest auth through its async
client.  Using the async functions and the new async keywords requires
removing Python 3.6 support.  In particular, this allows us to use async
and await keywoards.  Setting up the async APIs unfortunately requires a
rough doubling of the API to add both sync and async code to get
functions of the appropriate color.  Where there is a reasonable amount
of non-I/O logic, this is refactored out into common functions.