### PR TITLE
Bump version 1.9.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,8 +9,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 define([VERSION_MAJOR], [1])
-define([VERSION_MINOR], [8])
-define([VERSION_FIX], [1])
+define([VERSION_MINOR], [9])
+define([VERSION_FIX], [0])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
 define([VERSION_SUFFIX], [_master])
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 setup(
     name="amcrest",
-    version="1.8.1",
+    version="1.9.0",
     description="Python wrapper implementation for Amcrest cameras.",
     long_description=readme(),
     author="Douglas Schilling Landgraf, Marcelo Moreira de Mello",
@@ -33,7 +33,6 @@ setup(
     keywords="amcrest camera python",
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Breaking changes
* Drop support for Python 3.6.

New features
* Add new async APIs.

Minor fixes
* Change all system properties, such as hardware_version, to be parsed
  out.
* Fix the audio enabled to correctly return the value for the given
  channel.  This is equivelant to the video fix added in 1.8.1.
* Handle errors fetching the record mode more gracefully.
* Fix the move left/right PTZ commands to take speed as "horizontal".
* Change PTZ commands to return bool rather than str with "ok".