### PR TITLE
Add vendor_information parsing for 1.9.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 # GNU General Public License for more details.
 define([VERSION_MAJOR], [1])
 define([VERSION_MINOR], [9])
-define([VERSION_FIX], [0])
+define([VERSION_FIX], [1])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
 define([VERSION_SUFFIX], [_master])
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 setup(
     name="amcrest",
-    version="1.9.0",
+    version="1.9.1",
     description="Python wrapper implementation for Amcrest cameras.",
     long_description=readme(),
     author="Douglas Schilling Landgraf, Marcelo Moreira de Mello",

--- a/src/amcrest/system.py
+++ b/src/amcrest/system.py
@@ -155,11 +155,11 @@ class System(Http):
 
     @property
     def vendor_information(self) -> str:
-        return self._magic_box("getVendor")
+        return pretty(self._magic_box("getVendor"))
 
     @property
     async def async_vendor_information(self) -> str:
-        return await self._async_magic_box("getVendor")
+        return await pretty(self._async_magic_box("getVendor"))
 
     @property
     def onvif_information(self) -> str:


### PR DESCRIPTION
The `vendor_information` system property was missed in adding pretty
parsing to the system properties.  Add this and bump version 1.9.1.