### PR TITLE
Change caught httpx error type

### DIFF
--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -350,7 +350,7 @@ class Http:
                         self._async_token = None
                         raise LoginError()
                     resp.raise_for_status()
-                except httpx.RequestError as error:
+                except httpx.HTTPError as error:
                     _LOGGER.debug(
                         "%s Query %i failed due to error: %r",
                         self,


### PR DESCRIPTION
Change to catch the top level httpx exception. The current exception type will catch some request errors (eg timeouts) but will not catch http status errors (eg 500 errors). Changing the error type here will allow users to more easily handle spurious errors of this type.