### PR TITLE
Add github action to automate creating PyPI packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+on:
+  push:
+    branches-ignore: ['*']
+    tags: ['*']
+  release:
+    types: [published]
+jobs:
+  build-source:
+    name: Push source build
+    runs-on: ubuntu-latest
+    env:
+      python-version: "3.10"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip setuptools wheel
+      - name: Build source
+        run: |
+          python setup.py bdist_wheel
+          python setup.py sdist
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'release'
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Add a new github action that will build and upload PyPI packages when new releases are cut. This works by running but not uploading the package when a tag is created, then, when the Github release is published, the build is run and the package is pushed to PyPI.

To work, this will also require a PyPI API token. I am able to generate a token, but do not have access to add it as a Github Actions secret to this repo.