### PR TITLE
Raise timeout exception from async stream

### DIFF
--- a/src/amcrest/exceptions.py
+++ b/src/amcrest/exceptions.py
@@ -9,6 +9,10 @@ class AmcrestError(Exception):
     """General Amcrest error occurred."""
 
 
+class ReadTimeoutError(AmcrestError):
+    """A read timeout error occurred."""
+
+
 class CommError(AmcrestError):
     """A communication error occurred."""
 

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -28,7 +28,7 @@ from .config import (
     MAX_RETRY_HTTP_CONNECTION,
     TIMEOUT_HTTP_PROTOCOL,
 )
-from .exceptions import CommError, LoginError
+from .exceptions import CommError, LoginError, ReadTimeoutError
 from .utils import clean_url, pretty
 
 _LOGGER = logging.getLogger(__name__)
@@ -425,7 +425,10 @@ class Http:
                         cmd_id,
                         error,
                     )
-                    raise CommError(error) from error
+                    if isinstance(error, httpx.ReadTimeout):
+                        raise ReadTimeoutError(error) from error
+                    else:
+                        raise CommError(error) from error
 
     def command_audio(
         self,


### PR DESCRIPTION
Using httpx, the `.stream` method does not raise an exception when the
device goes offline if the read timeout is disabled. To get around this,
introduce a new exception that will be thrown if a timeout is hit so it
can more easily be handled and the stream reconnected as needed.  Add
handling logic to the async_event_stream so it behaves like the
non-async method by retrying while read errors are thrown.