### PR TITLE
Improve event handling in async stream

### DIFF
--- a/src/amcrest/event.py
+++ b/src/amcrest/event.py
@@ -58,6 +58,7 @@ async def _async_event_info(ret: AsyncIterable[str], length: int) -> str:
         line.append(char)
         if len(line) == length:
             return "".join(line)
+    raise CommError()
 
 
 class Event(Http):

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -401,8 +401,8 @@ class Http:
             verify=self._verify,
             timeout=httpx_timeout,
         ) as client:
-            async with client.stream("GET", url) as resp:
-                try:
+            try:
+                async with client.stream("GET", url) as resp:
                     if resp.status_code == 401:
                         _LOGGER.debug(
                             "%s Query %i: Unauthorized (401)", self, cmd_id
@@ -418,17 +418,17 @@ class Http:
                         resp.status_code,
                     )
                     yield resp
-                except httpx.RequestError as error:
-                    _LOGGER.debug(
-                        "%s Query %i failed due to error: %r",
-                        self,
-                        cmd_id,
-                        error,
-                    )
-                    if isinstance(error, httpx.ReadTimeout):
-                        raise ReadTimeoutError(error) from error
-                    else:
-                        raise CommError(error) from error
+            except httpx.HTTPError as error:
+                _LOGGER.debug(
+                    "%s Query %i failed due to error: %r",
+                    self,
+                    cmd_id,
+                    error,
+                )
+                if isinstance(error, httpx.ReadTimeout):
+                    raise ReadTimeoutError(error) from error
+                else:
+                    raise CommError(error) from error
 
     def command_audio(
         self,


### PR DESCRIPTION
Previous changes were made to the async command to allow that to handle
read timeouts better, and to correctly wrap all of the httpx exception
types. Not all of these changes were correctly applied to the async
stream command as well. This change correctly sets this error handling
for all async commands. This has been tested for both normal and
streaming async commands to ensure the proper wrapped exception type is
applied in all cases.