### PR TITLE
Fix factory_close and factory_destroy

### DIFF
--- a/src/amcrest/media.py
+++ b/src/amcrest/media.py
@@ -26,13 +26,13 @@ class Media(Http):
 
     def factory_close(self, factory_id: str) -> str:
         ret = self.command(
-            f"mediaFileFind.cgi?action=factory.close&object={factory_id}"
+            f"mediaFileFind.cgi?action=close&object={factory_id}"
         )
         return ret.content.decode()
 
     def factory_destroy(self, factory_id: str) -> str:
         ret = self.command(
-            f"mediaFileFind.cgi?action=factory.destroy&object={factory_id}"
+            f"mediaFileFind.cgi?action=destroy&object={factory_id}"
         )
         return ret.content.decode()
 


### PR DESCRIPTION
Removed the 'factory.' from the factory_close and factory_destroy API calls, since as per the documentation ( https://s3.amazonaws.com/amcrest-files/AMCREST_CGI_SDK_API.pdf ) the action for close and destroy is simply 'close' and 'destroy' without the 'factory.' prefix.