### PR TITLE
Only create httpx ssl context once

### DIFF
--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -150,7 +150,9 @@ class Http:
                 resp = self._command(cmd).content.decode()
             except LoginError:
                 _LOGGER.debug("%s Trying Digest Authentication", self)
-                self._token = requests.auth.HTTPDigestAuth(self._user, self._password)
+                self._token = requests.auth.HTTPDigestAuth(
+                    self._user, self._password
+                )
                 resp = self._command(cmd).content.decode()
         except CommError:
             self._token = None
@@ -171,7 +173,9 @@ class Http:
 
         _LOGGER.debug("%s Retrieving serial number", self)
         self._serial = pretty(
-            self._command("magicBox.cgi?action=getSerialNo").content.decode().strip()
+            self._command("magicBox.cgi?action=getSerialNo")
+            .content.decode()
+            .strip()
         )
 
     async def _async_generate_token(self) -> None:
@@ -184,7 +188,9 @@ class Http:
                 resp = (await self._async_command(cmd)).content.decode()
             except LoginError:
                 _LOGGER.debug("%s Trying async Digest Authentication", self)
-                self._async_token = httpx.DigestAuth(self._user, self._password)
+                self._async_token = httpx.DigestAuth(
+                    self._user, self._password
+                )
                 resp = (await self._async_command(cmd)).content.decode()
         except CommError:
             self._async_token = None
@@ -292,7 +298,9 @@ class Http:
                     SOHTTPAdapter(socket_options=_KEEPALIVE_OPTS),
                 )
             for loop in range(1, 2 + retries):
-                _LOGGER.debug("%s Running query %i attempt %s", self, cmd_id, loop)
+                _LOGGER.debug(
+                    "%s Running query %i attempt %s", self, cmd_id, loop
+                )
                 try:
                     resp = session.get(
                         url,
@@ -302,7 +310,9 @@ class Http:
                         verify=self._verify,
                     )
                     if resp.status_code == 401:
-                        _LOGGER.debug("%s Query %i: Unauthorized (401)", self, cmd_id)
+                        _LOGGER.debug(
+                            "%s Query %i: Unauthorized (401)", self, cmd_id
+                        )
                         self._token = None
                         raise LoginError()
                     resp.raise_for_status()
@@ -315,8 +325,12 @@ class Http:
                     )
                     if loop > retries:
                         raise CommError(error) from error
-                    msg = re.sub(r"at 0x[0-9a-fA-F]+", "at ADDRESS", repr(error))
-                    _LOGGER.warning("%s Trying again due to error: %s", self, msg)
+                    msg = re.sub(
+                        r"at 0x[0-9a-fA-F]+", "at ADDRESS", repr(error)
+                    )
+                    _LOGGER.warning(
+                        "%s Trying again due to error: %s", self, msg
+                    )
                     continue
                 else:
                     break
@@ -361,11 +375,15 @@ class Http:
             timeout=httpx_timeout,
         ) as client:
             for loop in range(1, 2 + retries):
-                _LOGGER.debug("%s Running query %i attempt %s", self, cmd_id, loop)
+                _LOGGER.debug(
+                    "%s Running query %i attempt %s", self, cmd_id, loop
+                )
                 try:
                     resp = await client.get(url)
                     if resp.status_code == 401:
-                        _LOGGER.debug("%s Query %i: Unauthorized (401)", self, cmd_id)
+                        _LOGGER.debug(
+                            "%s Query %i: Unauthorized (401)", self, cmd_id
+                        )
                         self._async_token = None
                         raise LoginError()
                     resp.raise_for_status()
@@ -378,8 +396,12 @@ class Http:
                     )
                     if loop > retries:
                         raise CommError(error) from error
-                    msg = re.sub(r"at 0x[0-9a-fA-F]+", "at ADDRESS", repr(error))
-                    _LOGGER.warning("%s Trying again due to error: %s", self, msg)
+                    msg = re.sub(
+                        r"at 0x[0-9a-fA-F]+", "at ADDRESS", repr(error)
+                    )
+                    _LOGGER.warning(
+                        "%s Trying again due to error: %s", self, msg
+                    )
                     continue
                 else:
                     break
@@ -419,7 +441,9 @@ class Http:
             try:
                 async with client.stream("GET", url) as resp:
                     if resp.status_code == 401:
-                        _LOGGER.debug("%s Query %i: Unauthorized (401)", self, cmd_id)
+                        _LOGGER.debug(
+                            "%s Query %i: Unauthorized (401)", self, cmd_id
+                        )
                         self._async_token = None
                         raise LoginError()
                     resp.raise_for_status()
@@ -468,7 +492,9 @@ class Http:
     # Helpers for common commands
 
     def _get_config(self, config_name: str) -> str:
-        ret = self.command(f"configManager.cgi?action=getConfig&name={config_name}")
+        ret = self.command(
+            f"configManager.cgi?action=getConfig&name={config_name}"
+        )
         return ret.content.decode()
 
     async def _async_get_config(self, config_name: str) -> str:

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -57,10 +57,12 @@ HttpxTimeoutT = Union[
     Tuple[Optional[float], Optional[float], Optional[float], Optional[float]],
 ]
 
+
 @lru_cache(maxsize=None)
 def create_default_ssl_context() -> ssl.SSLContext:
     """Return an SSL context that verifies the server certificate."""
     return ssl.create_default_context()
+
 
 @lru_cache(maxsize=None)
 def create_no_verify_ssl_context() -> ssl.SSLContext:

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -9,6 +9,7 @@
 #
 # vim:sw=4:ts=4:et
 import asyncio
+import contextlib
 from functools import lru_cache
 import logging
 import re

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import re
 import socket
+import ssl
 import threading
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Optional, Tuple, Union
@@ -45,6 +46,8 @@ try:
     ]
 except AttributeError:
     pass
+
+_DEFAULT_SSL_CONTEXT = ssl.create_default_context()
 
 TimeoutT = Union[Optional[float], Tuple[Optional[float], Optional[float]]]
 HttpxTimeoutT = Union[
@@ -336,6 +339,7 @@ class Http:
             auth=self._async_token,
             verify=self._verify,
             timeout=httpx_timeout,
+            verify=_DEFAULT_SSL_CONTEXT,
         ) as client:
             for loop in range(1, 2 + retries):
                 _LOGGER.debug(

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -9,6 +9,7 @@
 #
 # vim:sw=4:ts=4:et
 import asyncio
+from functools import lru_cache
 import logging
 import re
 import socket
@@ -47,7 +48,7 @@ try:
 except AttributeError:
     pass
 
-_DEFAULT_SSL_CONTEXT = ssl.create_default_context()
+
 
 TimeoutT = Union[Optional[float], Tuple[Optional[float], Optional[float]]]
 HttpxTimeoutT = Union[
@@ -55,6 +56,31 @@ HttpxTimeoutT = Union[
     Tuple[Optional[float], Optional[float], Optional[float], Optional[float]],
 ]
 
+@lru_cache(maxsize=None)
+def create_default_ssl_context() -> ssl.SSLContext:
+    """Return an SSL context that verifies the server certificate."""
+    return ssl.create_default_context()
+
+@lru_cache(maxsize=None)
+def create_no_verify_ssl_context() -> ssl.SSLContext:
+    """Return an SSL context that does not verify the server certificate.
+    This is a copy of aiohttp's create_default_context() function, with the
+    ssl verify turned off and old SSL versions enabled.
+
+    https://github.com/aio-libs/aiohttp/blob/33953f110e97eecc707e1402daa8d543f38a189b/aiohttp/connector.py#L911
+    """
+    sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    sslcontext.check_hostname = False
+    sslcontext.verify_mode = ssl.CERT_NONE
+    # Allow all ciphers rather than only Python 3.10 default
+    sslcontext.set_ciphers("DEFAULT")
+    with contextlib.suppress(AttributeError):
+        # This only works for OpenSSL >= 1.0.0
+        sslcontext.options |= ssl.OP_NO_COMPRESSION
+    sslcontext.set_default_verify_paths()
+    # ssl.OP_LEGACY_SERVER_CONNECT is only available in Python 3.12a4+
+    sslcontext.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0x4)
+    return sslcontext
 
 class SOHTTPAdapter(HTTPAdapter):
     """HTTPAdapter with support for socket options."""
@@ -334,12 +360,16 @@ class Http:
         else:
             httpx_timeout = timeout
 
+        if self._verify:
+            ssl_context = create_default_ssl_context()
+        else:
+            ssl_context = create_no_verify_ssl_context()
+
         async with httpx.AsyncClient(
             follow_redirects=True,
             auth=self._async_token,
-            verify=self._verify,
+            verify=ssl_context,
             timeout=httpx_timeout,
-            verify=_DEFAULT_SSL_CONTEXT,
         ) as client:
             for loop in range(1, 2 + retries):
                 _LOGGER.debug(

--- a/src/amcrest/http.py
+++ b/src/amcrest/http.py
@@ -50,7 +50,6 @@ except AttributeError:
     pass
 
 
-
 TimeoutT = Union[Optional[float], Tuple[Optional[float], Optional[float]]]
 HttpxTimeoutT = Union[
     Optional[float],
@@ -84,6 +83,7 @@ def create_no_verify_ssl_context() -> ssl.SSLContext:
     # ssl.OP_LEGACY_SERVER_CONNECT is only available in Python 3.12a4+
     sslcontext.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0x4)
     return sslcontext
+
 
 class SOHTTPAdapter(HTTPAdapter):
     """HTTPAdapter with support for socket options."""
@@ -150,9 +150,7 @@ class Http:
                 resp = self._command(cmd).content.decode()
             except LoginError:
                 _LOGGER.debug("%s Trying Digest Authentication", self)
-                self._token = requests.auth.HTTPDigestAuth(
-                    self._user, self._password
-                )
+                self._token = requests.auth.HTTPDigestAuth(self._user, self._password)
                 resp = self._command(cmd).content.decode()
         except CommError:
             self._token = None
@@ -173,9 +171,7 @@ class Http:
 
         _LOGGER.debug("%s Retrieving serial number", self)
         self._serial = pretty(
-            self._command("magicBox.cgi?action=getSerialNo")
-            .content.decode()
-            .strip()
+            self._command("magicBox.cgi?action=getSerialNo").content.decode().strip()
         )
 
     async def _async_generate_token(self) -> None:
@@ -188,9 +184,7 @@ class Http:
                 resp = (await self._async_command(cmd)).content.decode()
             except LoginError:
                 _LOGGER.debug("%s Trying async Digest Authentication", self)
-                self._async_token = httpx.DigestAuth(
-                    self._user, self._password
-                )
+                self._async_token = httpx.DigestAuth(self._user, self._password)
                 resp = (await self._async_command(cmd)).content.decode()
         except CommError:
             self._async_token = None
@@ -298,9 +292,7 @@ class Http:
                     SOHTTPAdapter(socket_options=_KEEPALIVE_OPTS),
                 )
             for loop in range(1, 2 + retries):
-                _LOGGER.debug(
-                    "%s Running query %i attempt %s", self, cmd_id, loop
-                )
+                _LOGGER.debug("%s Running query %i attempt %s", self, cmd_id, loop)
                 try:
                     resp = session.get(
                         url,
@@ -310,9 +302,7 @@ class Http:
                         verify=self._verify,
                     )
                     if resp.status_code == 401:
-                        _LOGGER.debug(
-                            "%s Query %i: Unauthorized (401)", self, cmd_id
-                        )
+                        _LOGGER.debug("%s Query %i: Unauthorized (401)", self, cmd_id)
                         self._token = None
                         raise LoginError()
                     resp.raise_for_status()
@@ -325,12 +315,8 @@ class Http:
                     )
                     if loop > retries:
                         raise CommError(error) from error
-                    msg = re.sub(
-                        r"at 0x[0-9a-fA-F]+", "at ADDRESS", repr(error)
-                    )
-                    _LOGGER.warning(
-                        "%s Trying again due to error: %s", self, msg
-                    )
+                    msg = re.sub(r"at 0x[0-9a-fA-F]+", "at ADDRESS", repr(error))
+                    _LOGGER.warning("%s Trying again due to error: %s", self, msg)
                     continue
                 else:
                     break
@@ -375,15 +361,11 @@ class Http:
             timeout=httpx_timeout,
         ) as client:
             for loop in range(1, 2 + retries):
-                _LOGGER.debug(
-                    "%s Running query %i attempt %s", self, cmd_id, loop
-                )
+                _LOGGER.debug("%s Running query %i attempt %s", self, cmd_id, loop)
                 try:
                     resp = await client.get(url)
                     if resp.status_code == 401:
-                        _LOGGER.debug(
-                            "%s Query %i: Unauthorized (401)", self, cmd_id
-                        )
+                        _LOGGER.debug("%s Query %i: Unauthorized (401)", self, cmd_id)
                         self._async_token = None
                         raise LoginError()
                     resp.raise_for_status()
@@ -396,12 +378,8 @@ class Http:
                     )
                     if loop > retries:
                         raise CommError(error) from error
-                    msg = re.sub(
-                        r"at 0x[0-9a-fA-F]+", "at ADDRESS", repr(error)
-                    )
-                    _LOGGER.warning(
-                        "%s Trying again due to error: %s", self, msg
-                    )
+                    msg = re.sub(r"at 0x[0-9a-fA-F]+", "at ADDRESS", repr(error))
+                    _LOGGER.warning("%s Trying again due to error: %s", self, msg)
                     continue
                 else:
                     break
@@ -441,9 +419,7 @@ class Http:
             try:
                 async with client.stream("GET", url) as resp:
                     if resp.status_code == 401:
-                        _LOGGER.debug(
-                            "%s Query %i: Unauthorized (401)", self, cmd_id
-                        )
+                        _LOGGER.debug("%s Query %i: Unauthorized (401)", self, cmd_id)
                         self._async_token = None
                         raise LoginError()
                     resp.raise_for_status()
@@ -492,9 +468,7 @@ class Http:
     # Helpers for common commands
 
     def _get_config(self, config_name: str) -> str:
-        ret = self.command(
-            f"configManager.cgi?action=getConfig&name={config_name}"
-        )
+        ret = self.command(f"configManager.cgi?action=getConfig&name={config_name}")
         return ret.content.decode()
 
     async def _async_get_config(self, config_name: str) -> str:


### PR DESCRIPTION
fixes #230

It would be better to keep the httpx client around and reuse it but that would be a more invasive change.