### PR TITLE
Remove distutils dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,10 +42,7 @@ AC_PATH_PROG([PYTHON3], [python3], [no])
     AC_SUBST([PYTHON3_PREFIX], ['${prefix}'])
     AC_SUBST([PYTHON3_EXEC_PREFIX], ['${exec_prefix}'])
 
-    PYTHON3_DIR=`$PYTHON3 -c "import distutils.sysconfig; \
-        print(distutils.sysconfig.get_python_lib(0,0,prefix='$PYTHON3_PREFIX'))"`
-    PYTHON3_EXECDIR=`$PYTHON3 -c "import distutils.sysconfig; \
-        print(distutils.sysconfig.get_python_lib(1,0,prefix='$PYTHON3_EXEC_PREFIX'))"`
+
 
     AC_SUBST(PYTHON3_CFLAGS)
     AC_SUBST(PYTHON3_LIBS)

--- a/src/amcrest/utils.py
+++ b/src/amcrest/utils.py
@@ -14,12 +14,21 @@ from datetime import datetime
 from typing import List
 
 # pylint: disable=no-name-in-module
-from distutils import util
+#from distutils import util
 from typing import List, Tuple, Union
 
 DATEFMT = "%Y-%m-%d %H:%M:%S"
 PRECISION = 2
 
+
+def strtobool(value: str) -> bool:
+    """Convert string to boolean."""
+    if s.lower() in ['yes', 'true', 't', 'y', '1']:
+        return True
+    elif s.lower() in ['no', 'false', 'f', 'n', '0']:
+        return False
+    else:
+        raise ValueError("Cannot convert {} to a bool".format(s))
 
 def clean_url(url: str) -> str:
     host = re.sub(r"^http[s]?://", "", url, flags=re.IGNORECASE)


### PR DESCRIPTION
The [distutils](https://peps.python.org/pep-0632/) module was deprecated in python 3.10 and is removed from 3.12. This pull request implements `strtobool` as a function following the description  [here](https://docs.python.org/3.9/distutils/apiref.html#distutils.util.strtobool).