### PR TITLE
Python 3.12+ compatible, get rid of distutils in py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 setup(
     name="amcrest",
-    version="1.9.8",
+    version="1.9.9",
     description="Python wrapper implementation for Amcrest cameras.",
     long_description=readme(),
     author="Douglas Schilling Landgraf, Marcelo Moreira de Mello",
@@ -37,5 +37,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/src/amcrest/utils.py
+++ b/src/amcrest/utils.py
@@ -14,12 +14,10 @@ from datetime import datetime
 from typing import List
 
 # pylint: disable=no-name-in-module
-from distutils import util
 from typing import List, Tuple, Union
 
 DATEFMT = "%Y-%m-%d %H:%M:%S"
 PRECISION = 2
-
 
 def clean_url(url: str) -> str:
     host = re.sub(r"^http[s]?://", "", url, flags=re.IGNORECASE)
@@ -53,7 +51,7 @@ def str2bool(value: Union[str, int]) -> bool:
          False values: n, no, false, off, 0
     """
     if isinstance(value, str):
-        return bool(util.strtobool(value))
+        return value.lower() in ("y", "yes", "on", "1", "true", "t")
     return bool(value)
 
 


### PR DESCRIPTION
Remove distutils from Python code, so it can be used with Python 3.12+.
(_Not_ converted distutils.sysconfig.get_python_lib to e.g. sysconfig.get_path)

Presently pyamcrest does not work with Home Assistant for recent months, as they now require Python 3.12+ 